### PR TITLE
update github actions for new main

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -1,5 +1,6 @@
 on:
   pull_request_target:
+    types: [opened, synchronize, reopened, labeled, unlabeled]
 
 name: Changelog check
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: [master]
+    branches: [main, staging, trying]
   pull_request:
 
 jobs:
@@ -40,5 +40,3 @@ jobs:
 
       - name: build examples
         run: cargo build --examples --target=thumbv6m-none-eabi
-
-

--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -1,6 +1,6 @@
 on:
   push:
-    branches: [ staging, trying, master ]
+    branches: [main, staging, trying]
   pull_request:
 
 name: Clippy check
@@ -18,4 +18,4 @@ jobs:
       - uses: actions-rs/clippy-check@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          args: --examples
+          args: --examples -- -D warnings

--- a/.github/workflows/rustfmt.yml
+++ b/.github/workflows/rustfmt.yml
@@ -1,6 +1,6 @@
 on:
   push:
-    branches: [ staging, trying, master ]
+    branches: [main, staging, trying]
   pull_request:
 
 name: Code formatting check


### PR DESCRIPTION
This also adds in the `labeled` and `unlabeled` types for the changelog workflow so that it is re-run when the `no changelog` label is added.

I had some difficulty with the changelog workflow. It doesn't always seem to correctly detect if the PR has the `no changelog` label.