### PR TITLE
Minor fixes to xtask bump

### DIFF
--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -5,3 +5,4 @@ edition = "2018"
 
 [dependencies]
 cargo_toml = "0.9.1"
+chrono = "0.4.19"


### PR DESCRIPTION
- check for the correct (no changes) string
- insert the new version link in the correct place