### PR TITLE
Introduce Board struct

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   APIs to be more aligned with each other.
 - Add BLE Beacon demo.
 - Add a simple speaker demo for micro:bit V2.
+- Add Board struct following the pattern used in other nrf board support crates.
 
 ## [0.10.1] - 2021-05-25
 

--- a/examples/display-blocking/src/main.rs
+++ b/examples/display-blocking/src/main.rs
@@ -7,36 +7,16 @@ use panic_halt as _;
 use cortex_m_rt::entry;
 
 use microbit::{
-    display_pins,
-    hal::{gpio::p0::Parts as P0Parts, prelude::*, Timer},
+    board::Board,
+    display::blocking::Display,
+    hal::{prelude::*, Timer},
 };
-
-#[cfg(feature = "v2")]
-use microbit::hal::gpio::p1::Parts as P1Parts;
-
-use microbit::display::blocking::Display;
 
 #[entry]
 fn main() -> ! {
-    if let Some(p) = microbit::pac::Peripherals::take() {
-        let mut timer = Timer::new(p.TIMER0);
-
-        // Set up pins
-        #[cfg(feature = "v1")]
-        let pins = {
-            let p0parts = P0Parts::new(p.GPIO);
-            display_pins!(p0parts)
-        };
-
-        #[cfg(feature = "v2")]
-        let pins = {
-            let p0parts = P0Parts::new(p.P0);
-            let p1parts = P1Parts::new(p.P1);
-            display_pins!(p0parts, p1parts)
-        };
-
-        // Display
-        let mut display = Display::new(pins);
+    if let Some(board) = Board::take() {
+        let mut timer = Timer::new(board.TIMER0);
+        let mut display = Display::new(board.display_pins);
 
         #[allow(non_snake_case)]
         let letter_I = [

--- a/examples/display-nonblocking/src/main.rs
+++ b/examples/display-nonblocking/src/main.rs
@@ -10,17 +10,14 @@ use cortex_m::peripheral::Peripherals;
 use cortex_m_rt::entry;
 
 use microbit::{
+    board::Board,
     display::nonblocking::{Display, GreyscaleImage},
-    display_pins,
     hal::{
-        gpio::p0::Parts as P0Parts,
+        clocks::Clocks,
         rtc::{Rtc, RtcInterrupt},
     },
     pac::{self, interrupt, RTC0, TIMER1},
 };
-
-#[cfg(feature = "v2")]
-use microbit::hal::gpio::p1::Parts as P1Parts;
 
 fn heart_image(inner_brightness: u8) -> GreyscaleImage {
     let b = inner_brightness;
@@ -41,34 +38,19 @@ static ANIM_TIMER: Mutex<RefCell<Option<Rtc<RTC0>>>> = Mutex::new(RefCell::new(N
 
 #[entry]
 fn main() -> ! {
-    if let Some(p) = pac::Peripherals::take() {
+    if let Some(board) = Board::take() {
         // Starting the low-frequency clock (needed for RTC to work)
-        p.CLOCK.tasks_lfclkstart.write(|w| unsafe { w.bits(1) });
-        while p.CLOCK.events_lfclkstarted.read().bits() == 0 {}
-        p.CLOCK.events_lfclkstarted.reset();
+        Clocks::new(board.CLOCK).start_lfclk();
 
         // RTC at 16Hz (32_768 / (2047 + 1))
         // 62.5ms period
-        let mut rtc0 = Rtc::new(p.RTC0, 2047).unwrap();
+        let mut rtc0 = Rtc::new(board.RTC0, 2047).unwrap();
         rtc0.enable_event(RtcInterrupt::Tick);
         rtc0.enable_interrupt(RtcInterrupt::Tick, None);
         rtc0.enable_counter();
 
-        // Set up pins
-        #[cfg(feature = "v1")]
-        let pins = {
-            let p0parts = P0Parts::new(p.GPIO);
-            display_pins!(p0parts)
-        };
-
-        #[cfg(feature = "v2")]
-        let pins = {
-            let p0parts = P0Parts::new(p.P0);
-            let p1parts = P1Parts::new(p.P1);
-            display_pins!(p0parts, p1parts)
-        };
-
-        let display = Display::new(p.TIMER1, pins);
+        // Create display
+        let display = Display::new(board.TIMER1, board.display_pins);
 
         cortex_m::interrupt::free(move |cs| {
             *DISPLAY.borrow(cs).borrow_mut() = Some(display);

--- a/examples/gpio-hal-blinky/src/main.rs
+++ b/examples/gpio-hal-blinky/src/main.rs
@@ -5,44 +5,21 @@ use panic_halt as _;
 
 use cortex_m_rt::entry;
 use embedded_hal::{blocking::delay::DelayMs, digital::v2::OutputPin};
-use microbit::hal::{
-    gpio::{p0, Level},
-    timer::Timer,
-};
+use microbit::{board::Board, hal::timer::Timer};
 
 #[entry]
 fn main() -> ! {
-    if let Some(p) = microbit::Peripherals::take() {
-        /* Split GPIO pins */
-        #[cfg(feature = "v1")]
-        let p0 = p0::Parts::new(p.GPIO);
+    let mut board = Board::take().unwrap();
 
-        #[cfg(feature = "v2")]
-        let p0 = p0::Parts::new(p.P0);
+    let mut timer = Timer::new(board.TIMER0);
 
-        let mut timer = Timer::new(p.TIMER0);
-
-        #[cfg(feature = "v1")]
-        let mut led = {
-            let _ = p0.p0_04.into_push_pull_output(Level::Low);
-            p0.p0_13.into_push_pull_output(Level::Low)
-        };
-
-        #[cfg(feature = "v2")]
-        let mut led = {
-            let _ = p0.p0_28.into_push_pull_output(Level::Low);
-            p0.p0_21.into_push_pull_output(Level::Low)
-        };
-
-        loop {
-            let _ = led.set_low();
-            timer.delay_ms(1_000_u16);
-            let _ = led.set_high();
-            timer.delay_ms(1_000_u16);
-        }
-    }
+    let _ = board.display_pins.col1.set_low();
+    let mut row1 = board.display_pins.row1;
 
     loop {
-        continue;
+        let _ = row1.set_low();
+        timer.delay_ms(1_000_u16);
+        let _ = row1.set_high();
+        timer.delay_ms(1_000_u16);
     }
 }

--- a/examples/gpio-hal-ledbutton/src/main.rs
+++ b/examples/gpio-hal-ledbutton/src/main.rs
@@ -5,78 +5,28 @@ use defmt_rtt as _;
 use panic_halt as _;
 
 use cortex_m_rt::entry;
-use microbit::hal::{
-    gpio::{p0, Level},
-    prelude::*,
-};
+use microbit::{board::Board, hal::prelude::*};
 
 #[entry]
 fn main() -> ! {
-    if let Some(p) = microbit::Peripherals::take() {
-        // Split GPIO pins
-        #[cfg(feature = "v1")]
-        let p0 = p0::Parts::new(p.GPIO);
+    let mut board = Board::take().unwrap();
 
-        #[cfg(feature = "v2")]
-        let p0 = p0::Parts::new(p.P0);
+    board.display_pins.row1.set_high().unwrap();
 
-        // Set row of LED matrix to permanent high
-        #[cfg(feature = "v1")]
-        let _ = p0.p0_13.into_push_pull_output(Level::Low).set_high();
-
-        #[cfg(feature = "v2")]
-        let _ = p0.p0_21.into_push_pull_output(Level::Low).set_high();
-
-        // Set 2 columns to output to control LED states
-        #[cfg(feature = "v1")]
-        let (mut led1, mut led2) = {
-            (
-                p0.p0_04.into_push_pull_output(Level::Low),
-                p0.p0_06.into_push_pull_output(Level::Low),
-            )
-        };
-
-        #[cfg(feature = "v2")]
-        let (mut led1, mut led2) = {
-            (
-                p0.p0_28.into_push_pull_output(Level::Low),
-                p0.p0_11.into_push_pull_output(Level::Low),
-            )
-        };
-
-        // Configure button GPIOs as inputs
-        #[cfg(feature = "v1")]
-        let (button_a, button_b) = {
-            (
-                p0.p0_17.into_floating_input(),
-                p0.p0_26.into_floating_input(),
-            )
-        };
-
-        #[cfg(feature = "v2")]
-        let (button_a, button_b) = {
-            (
-                p0.p0_14.into_floating_input(),
-                p0.p0_23.into_floating_input(),
-            )
-        };
-
-        loop {
-            if let Ok(true) = button_a.is_high() {
-                let _ = led1.set_high();
-            } else {
-                let _ = led1.set_low();
-            }
-
-            if let Ok(true) = button_b.is_high() {
-                let _ = led2.set_high();
-            } else {
-                let _ = led2.set_low();
-            }
-        }
-    }
+    let mut led1 = board.display_pins.col1;
+    let mut led2 = board.display_pins.col2;
 
     loop {
-        continue;
+        if let Ok(true) = board.buttons.button_a.is_high() {
+            let _ = led1.set_high();
+        } else {
+            let _ = led1.set_low();
+        }
+
+        if let Ok(true) = board.buttons.button_b.is_high() {
+            let _ = led2.set_high();
+        } else {
+            let _ = led2.set_low();
+        }
     }
 }

--- a/examples/gpio-hal-printbuttons/Cargo.toml
+++ b/examples/gpio-hal-printbuttons/Cargo.toml
@@ -12,8 +12,16 @@ defmt = "0.2.0"
 
 [dependencies.microbit]
 path = "../../microbit"
+optional = true
+
+[dependencies.microbit-v2]
+path = "../../microbit-v2"
+optional = true
 
 [features]
+v1 = ["microbit"]
+v2 = ["microbit-v2"]
+
 default = [
   "defmt-default",
 ]

--- a/examples/serial-hal-blocking-echo/src/main.rs
+++ b/examples/serial-hal-blocking-echo/src/main.rs
@@ -3,6 +3,7 @@
 
 use panic_halt as _;
 
+use core::fmt::Write;
 use microbit::hal;
 use microbit::hal::prelude::*;
 use microbit::hal::uart::Baudrate;
@@ -18,9 +19,7 @@ fn main() -> ! {
         let mut serial = microbit::serial_port!(gpio, p.UART0, Baudrate::BAUD115200);
 
         /* Print a nice hello message */
-        let s = b"Please type characters to echo:\r\n";
-
-        let _ = s.iter().map(|c| nb::block!(serial.write(*c))).last();
+        write!(serial, "Please type characters to echo:\r\n");
 
         /* Endless loop */
         loop {

--- a/microbit-common/src/board.rs
+++ b/microbit-common/src/board.rs
@@ -1,0 +1,6 @@
+//! Main Board
+#[cfg(feature = "v1")]
+pub use crate::v1::board::*;
+
+#[cfg(feature = "v2")]
+pub use crate::v2::board::*;

--- a/microbit-common/src/display/blocking.rs
+++ b/microbit-common/src/display/blocking.rs
@@ -9,30 +9,17 @@
 //! ```no_run
 //! # use microbit_common as microbit;
 //! # use microbit::{
-//! #     display_pins,
-//! #     pac,
-#![cfg_attr(feature = "v1", doc = "#     hal::{self, gpio::p0::Parts as P0Parts},")]
-#![cfg_attr(
-    feature = "v2",
-    doc = "#     hal::{self, gpio::{p0::Parts as P0Parts, p1::Parts as P1Parts}},"
-)]
+//! #     Board,
+//! #     hal,
 //! #     display::blocking::Display,
 //! # };
 //! # use embedded_hal::blocking::delay::DelayMs;
-//! // take the peripherals
-//! let p = pac::Peripherals::take().unwrap();
+//! // take the board
+//! let board = Board::take().unwrap();
 //! // make a timer
-//! let mut timer = hal::Timer::new(p.TIMER0);
-//! // set up the pins
-//! let mut pins = {
-#![cfg_attr(feature = "v1", doc = "   let p0parts = P0Parts::new(p.GPIO);")]
-#![cfg_attr(feature = "v1", doc = "   display_pins!(p0parts)")]
-#![cfg_attr(feature = "v2", doc = "   let p0parts = P0Parts::new(p.P0);")]
-#![cfg_attr(feature = "v2", doc = "   let p1parts = P1Parts::new(p.P1);")]
-#![cfg_attr(feature = "v2", doc = "   display_pins!(p0parts, p1parts)")]
-//! };
+//! let mut timer = hal::Timer::new(board.TIMER0);
 //! // create the Display
-//! let mut display = Display::new(pins);
+//! let mut display = Display::new(board.display_pins);
 //! // and light up some LEDs
 //! let heart = [
 //!     [0, 1, 0, 1, 0],

--- a/microbit-common/src/display/nonblocking/mod.rs
+++ b/microbit-common/src/display/nonblocking/mod.rs
@@ -18,32 +18,19 @@
 //! ```no_run
 //! # use microbit_common as microbit;
 //! use microbit::{
-//!     display_pins,
-//!     pac,
+//!     Board,
+//!     hal,
 //!     display::nonblocking::{Display, GreyscaleImage},
-#![cfg_attr(feature = "v1", doc = "    hal::{self, gpio::p0::Parts as P0Parts},")]
-#![cfg_attr(
-    feature = "v2",
-    doc = "    hal::{self, gpio::{p0::Parts as P0Parts, p1::Parts as P1Parts}},"
-)]
 //! };
 //! use embedded_hal::blocking::delay::DelayMs;
 //!
-//! let p = pac::Peripherals::take().unwrap();
+//! let board = Board::take().unwrap();
 //!
-//! let mut pins = {
-#![cfg_attr(feature = "v1", doc = "   let p0parts = P0Parts::new(p.GPIO);")]
-#![cfg_attr(feature = "v1", doc = "   display_pins!(p0parts)")]
-#![cfg_attr(feature = "v2", doc = "   let p0parts = P0Parts::new(p.P0);")]
-#![cfg_attr(feature = "v2", doc = "   let p1parts = P1Parts::new(p.P1);")]
-#![cfg_attr(feature = "v2", doc = "   display_pins!(p0parts, p1parts)")]
-//! };
-//!
-//! let mut display = Display::new(p.TIMER1, pins);
+//! let mut display = Display::new(board.TIMER1, board.display_pins);
 //!
 //! // in your main function
 //! {
-//!     let mut timer2 = hal::Timer::new(p.TIMER0);
+//!     let mut timer2 = hal::Timer::new(board.TIMER0);
 //!     loop {
 //!         display.show(&GreyscaleImage::new(&[
 //!             [0, 7, 0, 7, 0],
@@ -190,8 +177,8 @@ pub struct Display<T: Instance> {
 impl<T: Instance> Display<T> {
     /// Create and initialise the display driver
     ///
-    /// The [`display_pins!`](crate::display_pins) macro can be used
-    /// to create [`DisplayPins`].
+    /// [`DisplayPins`] can be used from [`Board::display_pins`](crate::Board::display_pins)
+    /// or the [`display_pins!`](crate::display_pins) macro can be used is manually.
     pub fn new(timer: T, pins: DisplayPins) -> Self {
         let mut display = Self {
             display: tiny_led_matrix::Display::new(),

--- a/microbit-common/src/lib.rs
+++ b/microbit-common/src/lib.rs
@@ -18,8 +18,11 @@ pub use nrf52833_hal as hal;
 pub use hal::pac;
 pub use hal::pac::Peripherals;
 
+pub mod board;
 pub mod display;
 pub mod gpio;
+
+pub use board::Board;
 
 #[cfg(feature = "v1")]
 mod v1;

--- a/microbit-common/src/v1/board.rs
+++ b/microbit-common/src/v1/board.rs
@@ -1,0 +1,202 @@
+use super::gpio::{DisplayPins, BTN_A, BTN_B};
+use crate::{
+    hal::gpio::{p0, Disconnected, Level},
+    pac,
+};
+
+/// Provides access to the micrbobit
+#[allow(non_snake_case)]
+pub struct Board {
+    /// GPIO pins that are not otherwise used
+    pub pins: Pins,
+
+    /// display pins
+    pub display_pins: DisplayPins,
+
+    /// buttons
+    pub buttons: Buttons,
+
+    /// Core peripheral: Cache and branch predictor maintenance operations
+    pub CBP: pac::CBP,
+
+    /// Core peripheral: CPUID
+    pub CPUID: pac::CPUID,
+
+    /// Core peripheral: Debug Control Block
+    pub DCB: pac::DCB,
+
+    /// Core peripheral: Data Watchpoint and Trace unit
+    pub DWT: pac::DWT,
+
+    /// Core peripheral: Flash Patch and Breakpoint unit
+    pub FPB: pac::FPB,
+
+    /// Core peripheral: Instrumentation Trace Macrocell
+    pub ITM: pac::ITM,
+
+    /// Core peripheral: Memory Protection Unit
+    pub MPU: pac::MPU,
+
+    /// Core peripheral: Nested Vector Interrupt Controller
+    pub NVIC: pac::NVIC,
+
+    /// Core peripheral: System Control Block
+    pub SCB: pac::SCB,
+
+    /// Core peripheral: SysTick Timer
+    pub SYST: pac::SYST,
+
+    /// Core peripheral: Trace Port Interface Unit
+    pub TPIU: pac::TPIU,
+
+    /// nRF51 peripheral: CLOCK
+    pub CLOCK: pac::CLOCK,
+
+    /// nRF51 peripheral: FICR
+    pub FICR: pac::FICR,
+
+    /// nRF51 peripheral: GPIOTE
+    pub GPIOTE: pac::GPIOTE,
+
+    /// nRF51 peripheral: RADIO
+    pub RADIO: pac::RADIO,
+
+    /// nRF51 peripheral: RNG
+    pub RNG: pac::RNG,
+
+    /// nRF51 peripheral: RTC0
+    pub RTC0: pac::RTC0,
+
+    /// nRF51 peripheral: TIMER0
+    pub TIMER0: pac::TIMER0,
+
+    /// nRF51 peripheral: TIMER1
+    pub TIMER1: pac::TIMER1,
+
+    /// nRF51 peripheral: TIMER2
+    pub TIMER2: pac::TIMER2,
+}
+
+impl Board {
+    /// Take the peripherals safely
+    ///
+    /// This method will return an instance of the board the first time it is
+    /// called. It will return only `None` on subsequent calls.
+    pub fn take() -> Option<Self> {
+        Some(Self::new(
+            pac::Peripherals::take()?,
+            pac::CorePeripherals::take()?,
+        ))
+    }
+
+    fn new(p: pac::Peripherals, cp: pac::CorePeripherals) -> Self {
+        let p0parts = p0::Parts::new(p.GPIO);
+        Self {
+            pins: Pins {
+                p0_00: p0parts.p0_00,
+                p0_01: p0parts.p0_01,
+                p0_02: p0parts.p0_02,
+                p0_03: p0parts.p0_03,
+                p0_16: p0parts.p0_16,
+                p0_18: p0parts.p0_18,
+                p0_19: p0parts.p0_19,
+                p0_20: p0parts.p0_20,
+                p0_21: p0parts.p0_21,
+                p0_22: p0parts.p0_22,
+                p0_23: p0parts.p0_23,
+                p0_24: p0parts.p0_24,
+                p0_25: p0parts.p0_25,
+                p0_27: p0parts.p0_27,
+                p0_28: p0parts.p0_28,
+                p0_29: p0parts.p0_29,
+                p0_30: p0parts.p0_30,
+            },
+            display_pins: DisplayPins {
+                row1: p0parts.p0_13.into_push_pull_output(Level::High),
+                row2: p0parts.p0_14.into_push_pull_output(Level::High),
+                row3: p0parts.p0_15.into_push_pull_output(Level::High),
+                col1: p0parts.p0_04.into_push_pull_output(Level::Low),
+                col2: p0parts.p0_05.into_push_pull_output(Level::Low),
+                col3: p0parts.p0_06.into_push_pull_output(Level::Low),
+                col4: p0parts.p0_07.into_push_pull_output(Level::Low),
+                col5: p0parts.p0_08.into_push_pull_output(Level::Low),
+                col6: p0parts.p0_09.into_push_pull_output(Level::Low),
+                col7: p0parts.p0_10.into_push_pull_output(Level::Low),
+                col8: p0parts.p0_11.into_push_pull_output(Level::Low),
+                col9: p0parts.p0_12.into_push_pull_output(Level::Low),
+            },
+            buttons: Buttons {
+                button_a: p0parts.p0_17.into_floating_input(),
+                button_b: p0parts.p0_26.into_floating_input(),
+            },
+
+            // Core peripherals
+            CBP: cp.CBP,
+            CPUID: cp.CPUID,
+            DCB: cp.DCB,
+            DWT: cp.DWT,
+            FPB: cp.FPB,
+            ITM: cp.ITM,
+            MPU: cp.MPU,
+            NVIC: cp.NVIC,
+            SCB: cp.SCB,
+            SYST: cp.SYST,
+            TPIU: cp.TPIU,
+
+            // nRF51 peripherals
+            CLOCK: p.CLOCK,
+            FICR: p.FICR,
+            GPIOTE: p.GPIOTE,
+            RADIO: p.RADIO,
+            RNG: p.RNG,
+            RTC0: p.RTC0,
+            TIMER0: p.TIMER0,
+            TIMER1: p.TIMER1,
+            TIMER2: p.TIMER2,
+        }
+    }
+}
+
+/// Unused GPIO pins
+#[allow(missing_docs)]
+pub struct Pins {
+    pub p0_00: p0::P0_00<Disconnected>,
+    pub p0_01: p0::P0_01<Disconnected>,
+    pub p0_02: p0::P0_02<Disconnected>,
+    pub p0_03: p0::P0_03<Disconnected>,
+    // pub p0_04: p0::P0_04<Disconnected>, // LEDs
+    // pub p0_05: p0::P0_05<Disconnected>, // LEDs
+    // pub p0_06: p0::P0_06<Disconnected>, // LEDs
+    // pub p0_07: p0::P0_07<Disconnected>, // LEDs
+    // pub p0_08: p0::P0_08<Disconnected>, // LEDs
+    // pub p0_09: p0::P0_09<Disconnected>, // LEDs
+    // pub p0_10: p0::P0_10<Disconnected>, // LEDs
+    // pub p0_11: p0::P0_11<Disconnected>, // LEDs
+    // pub p0_12: p0::P0_12<Disconnected>, // LEDs
+    // pub p0_13: p0::P0_13<Disconnected>, // LEDs
+    // pub p0_14: p0::P0_14<Disconnected>, // LEDs
+    // pub p0_15: p0::P0_15<Disconnected>, // LEDs
+    pub p0_16: p0::P0_16<Disconnected>,
+    // pub p0_17: p0::P0_17<Disconnected>, // BTN_A
+    pub p0_18: p0::P0_18<Disconnected>,
+    pub p0_19: p0::P0_19<Disconnected>,
+    pub p0_20: p0::P0_20<Disconnected>,
+    pub p0_21: p0::P0_21<Disconnected>,
+    pub p0_22: p0::P0_22<Disconnected>,
+    pub p0_23: p0::P0_23<Disconnected>,
+    pub p0_24: p0::P0_24<Disconnected>,
+    pub p0_25: p0::P0_25<Disconnected>,
+    // pub p0_26: p0::P0_26<Disconnected>, // BTN_B
+    pub p0_27: p0::P0_27<Disconnected>,
+    pub p0_28: p0::P0_28<Disconnected>,
+    pub p0_29: p0::P0_29<Disconnected>,
+    pub p0_30: p0::P0_30<Disconnected>,
+}
+
+/// Board buttons
+pub struct Buttons {
+    /// Left hand side button
+    pub button_a: BTN_A,
+    /// Right hand side button
+    pub button_b: BTN_B,
+}

--- a/microbit-common/src/v1/mod.rs
+++ b/microbit-common/src/v1/mod.rs
@@ -1,1 +1,2 @@
+pub mod board;
 pub mod gpio;

--- a/microbit-common/src/v2/board.rs
+++ b/microbit-common/src/v2/board.rs
@@ -1,0 +1,256 @@
+use super::gpio::{DisplayPins, BTN_A, BTN_B};
+use crate::{
+    hal::gpio::{p0, p1, Disconnected, Level},
+    pac,
+};
+
+/// Provides access to the micrbobit
+#[allow(non_snake_case)]
+pub struct Board {
+    /// GPIO pins that are not otherwise used
+    pub pins: Pins,
+
+    /// display pins
+    pub display_pins: DisplayPins,
+
+    /// buttons
+    pub buttons: Buttons,
+
+    /// speaker
+    pub speaker_pin: p0::P0_00<Disconnected>,
+
+    /// Core peripheral: Cache and branch predictor maintenance operations
+    pub CBP: pac::CBP,
+
+    /// Core peripheral: CPUID
+    pub CPUID: pac::CPUID,
+
+    /// Core peripheral: Debug Control Block
+    pub DCB: pac::DCB,
+
+    /// Core peripheral: Data Watchpoint and Trace unit
+    pub DWT: pac::DWT,
+
+    /// Core peripheral: Flash Patch and Breakpoint unit
+    pub FPB: pac::FPB,
+
+    /// Core peripheral: Floating Point Unit
+    pub FPU: pac::FPU,
+
+    /// Core peripheral: Instrumentation Trace Macrocell
+    pub ITM: pac::ITM,
+
+    /// Core peripheral: Memory Protection Unit
+    pub MPU: pac::MPU,
+
+    /// Core peripheral: Nested Vector Interrupt Controller
+    pub NVIC: pac::NVIC,
+
+    /// Core peripheral: System Control Block
+    pub SCB: pac::SCB,
+
+    /// Core peripheral: SysTick Timer
+    pub SYST: pac::SYST,
+
+    /// Core peripheral: Trace Port Interface Unit
+    pub TPIU: pac::TPIU,
+
+    /// nRF52 peripheral: CLOCK
+    pub CLOCK: pac::CLOCK,
+
+    /// nRF52 peripheral: FICR
+    pub FICR: pac::FICR,
+
+    /// nRF52 peripheral: GPIOTE
+    pub GPIOTE: pac::GPIOTE,
+
+    /// nRF52 peripheral: PWM0
+    pub PWM0: pac::PWM0,
+
+    /// nRF52 peripheral: PWM1
+    pub PWM1: pac::PWM1,
+
+    /// nRF52 peripheral: PWM2
+    pub PWM2: pac::PWM2,
+
+    /// nRF52 peripheral: PWM3
+    pub PWM3: pac::PWM3,
+
+    /// nRF52 peripheral: RADIO
+    pub RADIO: pac::RADIO,
+
+    /// nRF52 peripheral: RNG
+    pub RNG: pac::RNG,
+
+    /// nRF52 peripheral: RTC0
+    pub RTC0: pac::RTC0,
+
+    /// nRF52 peripheral: TIMER0
+    pub TIMER0: pac::TIMER0,
+
+    /// nRF52 peripheral: TIMER1
+    pub TIMER1: pac::TIMER1,
+
+    /// nRF52 peripheral: TIMER2
+    pub TIMER2: pac::TIMER2,
+
+    /// nRF52 peripheral: TIMER3
+    pub TIMER3: pac::TIMER3,
+
+    /// nRF52 peripheral: TIMER4
+    pub TIMER4: pac::TIMER4,
+}
+
+impl Board {
+    /// Take the peripherals safely
+    ///
+    /// This method will return an instance of the board the first time it is
+    /// called. It will return only `None` on subsequent calls.
+    pub fn take() -> Option<Self> {
+        Some(Self::new(
+            pac::Peripherals::take()?,
+            pac::CorePeripherals::take()?,
+        ))
+    }
+
+    fn new(p: pac::Peripherals, cp: pac::CorePeripherals) -> Self {
+        let p0parts = p0::Parts::new(p.P0);
+        let p1parts = p1::Parts::new(p.P1);
+        Self {
+            pins: Pins {
+                p0_01: p0parts.p0_01,
+                p0_02: p0parts.p0_02,
+                p0_03: p0parts.p0_03,
+                p0_04: p0parts.p0_04,
+                p0_05: p0parts.p0_05,
+                p0_06: p0parts.p0_06,
+                p0_07: p0parts.p0_07,
+                p0_08: p0parts.p0_08,
+                p0_09: p0parts.p0_09,
+                p0_10: p0parts.p0_10,
+                p0_12: p0parts.p0_12,
+                p0_13: p0parts.p0_13,
+                p0_16: p0parts.p0_16,
+                p0_17: p0parts.p0_17,
+                p0_18: p0parts.p0_18,
+                p0_20: p0parts.p0_20,
+                p0_25: p0parts.p0_25,
+                p0_26: p0parts.p0_26,
+                p0_27: p0parts.p0_27,
+                p0_29: p0parts.p0_29,
+                p1_00: p1parts.p1_00,
+                p1_01: p1parts.p1_01,
+                p1_02: p1parts.p1_02,
+                p1_03: p1parts.p1_03,
+                p1_04: p1parts.p1_04,
+                p1_06: p1parts.p1_06,
+                p1_07: p1parts.p1_07,
+                p1_08: p1parts.p1_08,
+                p1_09: p1parts.p1_09,
+            },
+            display_pins: DisplayPins {
+                col1: p0parts.p0_28.into_push_pull_output(Level::High),
+                col2: p0parts.p0_11.into_push_pull_output(Level::High),
+                col3: p0parts.p0_31.into_push_pull_output(Level::High),
+                col4: p1parts.p1_05.into_push_pull_output(Level::High),
+                col5: p0parts.p0_30.into_push_pull_output(Level::High),
+                row1: p0parts.p0_21.into_push_pull_output(Level::Low),
+                row2: p0parts.p0_22.into_push_pull_output(Level::Low),
+                row3: p0parts.p0_15.into_push_pull_output(Level::Low),
+                row4: p0parts.p0_24.into_push_pull_output(Level::Low),
+                row5: p0parts.p0_19.into_push_pull_output(Level::Low),
+            },
+            buttons: Buttons {
+                button_a: p0parts.p0_14.into_floating_input(),
+                button_b: p0parts.p0_23.into_floating_input(),
+            },
+            speaker_pin: p0parts.p0_00,
+
+            // Core peripherals
+            CBP: cp.CBP,
+            CPUID: cp.CPUID,
+            DCB: cp.DCB,
+            DWT: cp.DWT,
+            FPB: cp.FPB,
+            FPU: cp.FPU,
+            ITM: cp.ITM,
+            MPU: cp.MPU,
+            NVIC: cp.NVIC,
+            SCB: cp.SCB,
+            SYST: cp.SYST,
+            TPIU: cp.TPIU,
+
+            // nRF52 peripherals
+            CLOCK: p.CLOCK,
+            FICR: p.FICR,
+            GPIOTE: p.GPIOTE,
+            PWM0: p.PWM0,
+            PWM1: p.PWM1,
+            PWM2: p.PWM2,
+            PWM3: p.PWM3,
+            RADIO: p.RADIO,
+            RNG: p.RNG,
+            RTC0: p.RTC0,
+            TIMER0: p.TIMER0,
+            TIMER1: p.TIMER1,
+            TIMER2: p.TIMER2,
+            TIMER3: p.TIMER3,
+            TIMER4: p.TIMER4,
+        }
+    }
+}
+
+/// Unused GPIO pins
+#[allow(missing_docs)]
+pub struct Pins {
+    // pub p0_00: p0::P0_00<Disconnected>,  Speaker
+    pub p0_01: p0::P0_01<Disconnected>,
+    pub p0_02: p0::P0_02<Disconnected>,
+    pub p0_03: p0::P0_03<Disconnected>,
+    pub p0_04: p0::P0_04<Disconnected>,
+    pub p0_05: p0::P0_05<Disconnected>,
+    pub p0_06: p0::P0_06<Disconnected>,
+    pub p0_07: p0::P0_07<Disconnected>,
+    pub p0_08: p0::P0_08<Disconnected>,
+    pub p0_09: p0::P0_09<Disconnected>,
+    pub p0_10: p0::P0_10<Disconnected>,
+    // pub p0_11: p0::P0_11<Disconnected>, // LEDs
+    pub p0_12: p0::P0_12<Disconnected>,
+    pub p0_13: p0::P0_13<Disconnected>,
+    // pub p0_14: p0::P0_14<Disconnected>, // BTN_A
+    // pub p0_15: p0::P0_15<Disconnected>, // LEDs
+    pub p0_16: p0::P0_16<Disconnected>,
+    pub p0_17: p0::P0_17<Disconnected>,
+    pub p0_18: p0::P0_18<Disconnected>,
+    // pub p0_19: p0::P0_19<Disconnected>, // LEDs
+    pub p0_20: p0::P0_20<Disconnected>,
+    // pub p0_21: p0::P0_21<Disconnected>, // LEDs
+    // pub p0_22: p0::P0_22<Disconnected>, // LEDs
+    // pub p0_23: p0::P0_23<Disconnected>, // BTN_B
+    // pub p0_24: p0::P0_24<Disconnected>, // LEDs
+    pub p0_25: p0::P0_25<Disconnected>,
+    pub p0_26: p0::P0_26<Disconnected>,
+    pub p0_27: p0::P0_27<Disconnected>,
+    // pub p0_28: p0::P0_28<Disconnected>, // LEDs
+    pub p0_29: p0::P0_29<Disconnected>,
+    // pub p0_30: p0::P0_30<Disconnected>, // LEDs
+    // pub p0_31: p0::P0_31<Disconnected>, // LEDs
+    pub p1_00: p1::P1_00<Disconnected>,
+    pub p1_01: p1::P1_01<Disconnected>,
+    pub p1_02: p1::P1_02<Disconnected>,
+    pub p1_03: p1::P1_03<Disconnected>,
+    pub p1_04: p1::P1_04<Disconnected>,
+    // pub p1_05: p1::P1_05<Disconnected>, // LEDs
+    pub p1_06: p1::P1_06<Disconnected>,
+    pub p1_07: p1::P1_07<Disconnected>,
+    pub p1_08: p1::P1_08<Disconnected>,
+    pub p1_09: p1::P1_09<Disconnected>,
+}
+
+/// Buttons
+pub struct Buttons {
+    /// Left hand button
+    pub button_a: BTN_A,
+    /// Right hand button
+    pub button_b: BTN_B,
+}

--- a/microbit-common/src/v2/mod.rs
+++ b/microbit-common/src/v2/mod.rs
@@ -1,1 +1,2 @@
+pub mod board;
 pub mod gpio;


### PR DESCRIPTION
Introduce a Board struct similar to those in other nrf-rs board support crates. This makes for a much nicer API and allows for pretty much all of the feature switching to be removed from the examples.

I have added all the core peripherals but not all the peripherals yet as this doesn't seem to be what is done in the other BSPs. I have added all peripherals that are used in the examples so far.

As a quick example of how this improves things. Instead of doing this:
```rust
let p = pac::Peripherals::take().unwrap();
let mut timer = Timer::new(p.TIMER0);

// Set up pins
#[cfg(feature = "v1")]
let pins = {
  let p0parts = P0Parts::new(p.GPIO);
  display_pins!(p0parts)
};

#[cfg(feature = "v2")]
let pins = {
  let p0parts = P0Parts::new(p.P0);
  let p1parts = P1Parts::new(p.P1);
  display_pins!(p0parts, p1parts)
};

// Display
let mut display = Display::new(pins);
```

You can now do:
```rust
let board = Board::take().unwrap();
let mut timer = Timer::new(board.TIMER0);
let mut display = Display::new(board.display_pins);
```