### PR TITLE
Add magnetometer example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Add BLE Beacon demo.
 - Add a simple speaker demo for micro:bit V2.
 - Add Board struct following the pattern used in other nrf board support crates.
+- Add magnetometer example.
 
 ## [0.10.1] - 2021-05-25
 

--- a/examples/magnetometer/Cargo.toml
+++ b/examples/magnetometer/Cargo.toml
@@ -1,0 +1,35 @@
+[package]
+name = "magnetometer"
+version = "0.1.0"
+edition = "2018"
+
+[dependencies]
+cortex-m-rt = "0.6.12"
+panic-halt = "0.2.0"
+defmt-rtt = "0.2.0"
+defmt = "0.2.0"
+lsm303agr = "0.2.0"
+
+[dependencies.microbit]
+path = "../../microbit"
+optional = true
+
+[dependencies.microbit-v2]
+path = "../../microbit-v2"
+optional = true
+
+[features]
+v1 = ["microbit"]
+v2 = ["microbit-v2"]
+
+default = [
+  "defmt-default",
+]
+
+# do NOT modify these features
+defmt-default = []
+defmt-trace = []
+defmt-debug = []
+defmt-info = []
+defmt-warn = []
+defmt-error = []

--- a/examples/magnetometer/src/main.rs
+++ b/examples/magnetometer/src/main.rs
@@ -1,0 +1,80 @@
+#![no_std]
+#![no_main]
+
+use defmt_rtt as _;
+use panic_halt as _;
+
+use cortex_m_rt::entry;
+
+use microbit::hal::{prelude::*, Timer};
+
+#[cfg(feature = "v1")]
+use microbit::{
+    hal::twi,
+    pac::{twi0::frequency::FREQUENCY_A, TWI0},
+};
+#[cfg(feature = "v2")]
+use microbit::{
+    hal::twim,
+    pac::{twim0::frequency::FREQUENCY_A, TWIM0},
+};
+
+use lsm303agr::{
+    interface::I2cInterface, mode::MagOneShot, AccelMode, AccelOutputDataRate, Lsm303agr,
+};
+
+#[entry]
+fn main() -> ! {
+    let board = microbit::Board::take().unwrap();
+    let mut timer = Timer::new(board.TIMER0);
+
+    #[cfg(feature = "v1")]
+    let i2c = { twi::Twi::new(board.TWI0, board.i2c.into(), FREQUENCY_A::K100) };
+
+    #[cfg(feature = "v2")]
+    let i2c = { twim::Twim::new(board.TWIM0, board.i2c_internal.into(), FREQUENCY_A::K100) };
+
+    let mut sensor = Lsm303agr::new_with_i2c(i2c);
+    match sensor.accelerometer_id() {
+        Ok(0x33u8) => {}
+        _ => defmt::panic!("accelerometer not found"),
+    }
+    sensor.init().unwrap();
+    sensor.set_accel_odr(AccelOutputDataRate::Hz50).unwrap();
+
+    defmt::info!("normal mode");
+    sensor.set_accel_mode(AccelMode::Normal).unwrap();
+    timer.delay_ms(1000_u32);
+    get_data(&mut sensor);
+
+    defmt::info!("low power mode");
+    sensor.set_accel_mode(AccelMode::LowPower).unwrap();
+    timer.delay_ms(1000_u32);
+    get_data(&mut sensor);
+
+    defmt::info!("high resolution mode");
+    sensor.set_accel_mode(AccelMode::HighResolution).unwrap();
+    timer.delay_ms(1000_u32);
+    get_data(&mut sensor);
+
+    loop {
+        timer.delay_ms(100_u32);
+        get_data(&mut sensor);
+    }
+}
+
+#[cfg(feature = "v1")]
+type Sensor = Lsm303agr<I2cInterface<twi::Twi<TWI0>>, MagOneShot>;
+
+#[cfg(feature = "v2")]
+type Sensor = Lsm303agr<I2cInterface<twim::Twim<TWIM0>>, MagOneShot>;
+
+fn get_data(sensor: &mut Sensor) {
+    loop {
+        if sensor.accel_status().unwrap().xyz_new_data {
+            let data = sensor.accel_data().unwrap();
+            defmt::info!("x {} y {} z {}", data.x, data.y, data.z);
+            return;
+        }
+    }
+}

--- a/microbit-common/src/v1/gpio.rs
+++ b/microbit-common/src/v1/gpio.rs
@@ -127,7 +127,7 @@ pub type MOSI<MODE> = p0::P0_21<MODE>;
 pub type MISO<MODE> = p0::P0_22<MODE>;
 pub type SCK<MODE> = p0::P0_23<MODE>;
 
-/* i2c */
+/* i2c - shared external and internal */
 pub type SCL = p0::P0_00<Input<Floating>>;
 pub type SDA = p0::P0_30<Input<Floating>>;
 

--- a/microbit-common/src/v2/gpio.rs
+++ b/microbit-common/src/v2/gpio.rs
@@ -105,7 +105,11 @@ pub type MOSI<MODE> = p0::P0_13<MODE>;
 pub type MISO<MODE> = p0::P0_01<MODE>;
 pub type SCK<MODE> = p0::P0_17<MODE>;
 
-/* i2c */
+/* i2c - internal */
+pub type INT_SCL = p0::P0_08<Input<Floating>>;
+pub type INT_SDA = p0::P0_16<Input<Floating>>;
+
+/* i2c - external */
 pub type SCL = p0::P0_26<Input<Floating>>;
 pub type SDA = p1::P1_00<Input<Floating>>;
 


### PR DESCRIPTION
Uses LSM303AGR driver from eldruin mentioned here #27 (comment)

This example works on the micro:bit V1.5 and V2. The micro:bit V1.3 uses a different magnetometer.

Depends on #60 but does not need to