### PR TITLE
Initial UART(E) implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Add Board struct following the pattern used in other nrf board support crates.
 - Add magnetometer example.
 - LEDs on the micro:bit V1 are now turned off per default
+- UART(E) is now exposed in the same way as I2C
 
 ## [0.10.1] - 2021-05-25
 

--- a/examples/serial-hal-blocking-echo/Cargo.toml
+++ b/examples/serial-hal-blocking-echo/Cargo.toml
@@ -8,6 +8,7 @@ cortex-m-rt = "0.6.12"
 panic-halt = "0.2.0"
 defmt-rtt = "0.2.0"
 nb = "0.1.2"
+embedded-hal = "0.2.6"
 
 [dependencies.microbit]
 path = "../../microbit"

--- a/examples/serial-hal-blocking-echo/Cargo.toml
+++ b/examples/serial-hal-blocking-echo/Cargo.toml
@@ -11,3 +11,12 @@ nb = "0.1.2"
 
 [dependencies.microbit]
 path = "../../microbit"
+optional = true
+
+[dependencies.microbit-v2]
+path = "../../microbit-v2"
+optional = true
+
+[features]
+v1 = ["microbit"]
+v2 = ["microbit-v2"]

--- a/examples/serial-hal-blocking-echo/src/main.rs
+++ b/examples/serial-hal-blocking-echo/src/main.rs
@@ -19,16 +19,29 @@ use microbit::{
 
 use cortex_m_rt::entry;
 
-
 #[entry]
 fn main() -> ! {
     let board = microbit::Board::take().unwrap();
 
     #[cfg(feature = "v1")]
-    let mut serial = { uart::Uart::new(board.UART0, board.uart.into(), Parity::EXCLUDED, Baudrate::BAUD115200) };
+    let mut serial = {
+        uart::Uart::new(
+            board.UART0,
+            board.uart.into(),
+            Parity::EXCLUDED,
+            Baudrate::BAUD115200,
+        )
+    };
 
     #[cfg(feature = "v2")]
-    let mut serial = { uarte::Uarte::new(board.UARTE0, board.uart.into(), Parity::EXCLUDED, Baudrate::BAUD115200) };
+    let mut serial = {
+        uarte::Uarte::new(
+            board.UARTE0,
+            board.uart.into(),
+            Parity::EXCLUDED,
+            Baudrate::BAUD115200,
+        )
+    };
 
     /* Print a nice hello message */
     write!(serial, "Please type characters to echo:\r\n").unwrap();

--- a/examples/serial-hal-blocking-echo/src/main.rs
+++ b/examples/serial-hal-blocking-echo/src/main.rs
@@ -7,16 +7,16 @@ use core::fmt::Write;
 
 #[cfg(feature = "v1")]
 use microbit::{
+    hal::prelude::*,
     hal::uart,
     hal::uart::{Baudrate, Parity},
-    hal::prelude::*,
 };
 
 #[cfg(feature = "v2")]
 use microbit::{
+    hal::prelude::*,
     hal::uarte,
     hal::uarte::{Baudrate, Parity},
-    hal::prelude::*,
 };
 
 use cortex_m_rt::entry;
@@ -25,7 +25,6 @@ use cortex_m_rt::entry;
 mod serial_setup;
 #[cfg(feature = "v2")]
 use serial_setup::UartePort;
-
 
 #[entry]
 fn main() -> ! {

--- a/examples/serial-hal-blocking-echo/src/serial_setup.rs
+++ b/examples/serial-hal-blocking-echo/src/serial_setup.rs
@@ -1,0 +1,47 @@
+use microbit::hal::uarte::{Uarte, UarteTx, UarteRx, Instance, Error};
+use embedded_hal::serial;
+use embedded_hal::blocking::serial as bserial;
+use core::fmt;
+
+static mut TX_BUF: [u8; 1] = [0; 1];
+static mut RX_BUF: [u8; 1] = [0; 1];
+
+pub struct UartePort<T: Instance>(UarteTx<T>, UarteRx<T>);
+
+impl<T: Instance> UartePort<T> {
+    pub fn new(serial: Uarte<T>) -> UartePort<T> {
+        let (tx, rx) = serial.split(
+            unsafe { &mut TX_BUF },
+            unsafe { &mut RX_BUF }
+        ).unwrap();
+        UartePort(tx, rx)
+    }
+}
+
+impl<T: Instance> fmt::Write for UartePort<T> {
+    fn write_str(&mut self, s: &str) -> fmt::Result {
+	self.0.write_str(s)
+    }
+}
+
+impl<T: Instance> serial::Write<u8> for UartePort<T> {
+    type Error = Error;
+
+    fn write(&mut self, b: u8) -> nb::Result<(), Self::Error> {
+        self.0.write(b)
+    }
+
+    fn flush(&mut self) -> nb::Result<(), Self::Error> {
+        self.0.flush()
+    }
+}
+
+impl<T: Instance> bserial::write::Default<u8> for UartePort<T> {}
+
+impl<T: Instance> serial::Read<u8> for UartePort<T> {
+    type Error = Error;
+
+    fn read(&mut self) -> nb::Result<u8, Self::Error> {
+	self.1.read()
+    }
+}

--- a/examples/serial-hal-blocking-echo/src/serial_setup.rs
+++ b/examples/serial-hal-blocking-echo/src/serial_setup.rs
@@ -1,7 +1,7 @@
-use microbit::hal::uarte::{Uarte, UarteTx, UarteRx, Instance, Error};
-use embedded_hal::serial;
-use embedded_hal::blocking::serial as bserial;
 use core::fmt;
+use embedded_hal::blocking::serial as bserial;
+use embedded_hal::serial;
+use microbit::hal::uarte::{Error, Instance, Uarte, UarteRx, UarteTx};
 
 static mut TX_BUF: [u8; 1] = [0; 1];
 static mut RX_BUF: [u8; 1] = [0; 1];
@@ -10,17 +10,16 @@ pub struct UartePort<T: Instance>(UarteTx<T>, UarteRx<T>);
 
 impl<T: Instance> UartePort<T> {
     pub fn new(serial: Uarte<T>) -> UartePort<T> {
-        let (tx, rx) = serial.split(
-            unsafe { &mut TX_BUF },
-            unsafe { &mut RX_BUF }
-        ).unwrap();
+        let (tx, rx) = serial
+            .split(unsafe { &mut TX_BUF }, unsafe { &mut RX_BUF })
+            .unwrap();
         UartePort(tx, rx)
     }
 }
 
 impl<T: Instance> fmt::Write for UartePort<T> {
     fn write_str(&mut self, s: &str) -> fmt::Result {
-	self.0.write_str(s)
+        self.0.write_str(s)
     }
 }
 
@@ -42,6 +41,6 @@ impl<T: Instance> serial::Read<u8> for UartePort<T> {
     type Error = Error;
 
     fn read(&mut self) -> nb::Result<u8, Self::Error> {
-	self.1.read()
+        self.1.read()
     }
 }

--- a/examples/v2-speaker/src/main.rs
+++ b/examples/v2-speaker/src/main.rs
@@ -48,7 +48,7 @@ fn main() -> ! {
             let speaker = pwm::Pwm::new(board.PWM0);
             speaker
                 // output the waveform on the speaker pin
-                .set_output_pin(pwm::Channel::C0, &speaker_pin.degrade())
+                .set_output_pin(pwm::Channel::C0, speaker_pin.degrade())
                 // Use prescale by 16 to achive darker sounds
                 .set_prescaler(pwm::Prescaler::Div16)
                 // Initial frequency

--- a/microbit-common/Cargo.toml
+++ b/microbit-common/Cargo.toml
@@ -34,7 +34,8 @@ version = "0.12.1"
 
 [dependencies.nrf52833-hal]
 optional = true
-version = "0.12.1"
+version = "0.13.0"
+git = "https://github.com/nrf-rs/nrf-hal"
 
 [features]
 doc = []

--- a/microbit-common/Cargo.toml
+++ b/microbit-common/Cargo.toml
@@ -30,7 +30,7 @@ embedded-hal = "0.2.4"
 
 [dependencies.nrf51-hal]
 optional = true
-version = "0.12.1"
+version = "0.13.0"
 
 [dependencies.nrf52833-hal]
 optional = true

--- a/microbit-common/src/display/blocking.rs
+++ b/microbit-common/src/display/blocking.rs
@@ -72,12 +72,11 @@ impl Display {
     /// to create [`DisplayPins`].
     pub fn new(pins: DisplayPins) -> Self {
         let (cols, rows) = pins.degrade();
-        let mut retval = Display {
+        Display {
             delay_ms: DEFAULT_DELAY_MS,
             rows,
             cols,
-        };
-        retval
+        }
     }
 
     /// Clear the display

--- a/microbit-common/src/v1/board.rs
+++ b/microbit-common/src/v1/board.rs
@@ -1,9 +1,8 @@
-use super::gpio::{DisplayPins, BTN_A, BTN_B, SCL, SDA, UART_TX, UART_RX};
+use super::gpio::{DisplayPins, BTN_A, BTN_B, SCL, SDA, UART_RX, UART_TX};
 use crate::{
     hal::{
         gpio::{p0, Disconnected, Level},
-        twi,
-        uart,
+        twi, uart,
     },
     pac,
 };

--- a/microbit-common/src/v1/board.rs
+++ b/microbit-common/src/v1/board.rs
@@ -1,8 +1,9 @@
-use super::gpio::{DisplayPins, BTN_A, BTN_B, SCL, SDA};
+use super::gpio::{DisplayPins, BTN_A, BTN_B, SCL, SDA, UART_TX, UART_RX};
 use crate::{
     hal::{
         gpio::{p0, Disconnected, Level},
         twi,
+        uart,
     },
     pac,
 };
@@ -21,6 +22,9 @@ pub struct Board {
 
     /// I2C shared internal and external bus pins
     pub i2c: I2CPins,
+
+    /// UART to debugger pins
+    pub uart: UartPins,
 
     /// Core peripheral: Cache and branch predictor maintenance operations
     pub CBP: pac::CBP,
@@ -84,6 +88,9 @@ pub struct Board {
 
     /// nRF51 peripheral: TWI0
     pub TWI0: pac::TWI0,
+
+    /// nrf51 peripheral: UART0
+    pub UART0: pac::UART0,
 }
 
 impl Board {
@@ -112,8 +119,6 @@ impl Board {
                 p0_21: p0parts.p0_21,
                 p0_22: p0parts.p0_22,
                 p0_23: p0parts.p0_23,
-                p0_24: p0parts.p0_24,
-                p0_25: p0parts.p0_25,
                 p0_27: p0parts.p0_27,
                 p0_28: p0parts.p0_28,
                 p0_29: p0parts.p0_29,
@@ -140,6 +145,10 @@ impl Board {
                 scl: p0parts.p0_00.into_floating_input(),
                 sda: p0parts.p0_30.into_floating_input(),
             },
+            uart: UartPins {
+                tx: p0parts.p0_24.into_push_pull_output(Level::Low),
+                rx: p0parts.p0_25.into_floating_input(),
+            },
 
             // Core peripherals
             CBP: cp.CBP,
@@ -165,6 +174,7 @@ impl Board {
             TIMER1: p.TIMER1,
             TIMER2: p.TIMER2,
             TWI0: p.TWI0,
+            UART0: p.UART0,
         }
     }
 }
@@ -196,8 +206,8 @@ pub struct Pins {
     pub p0_21: p0::P0_21<Disconnected>,
     pub p0_22: p0::P0_22<Disconnected>,
     pub p0_23: p0::P0_23<Disconnected>,
-    pub p0_24: p0::P0_24<Disconnected>,
-    pub p0_25: p0::P0_25<Disconnected>,
+    // pub p0_24: p0::P0_24<Disconnected>, // UART TX
+    // pub p0_25: p0::P0_25<Disconnected>, // UART RX
     // pub p0_26: p0::P0_26<Disconnected>, // BTN_B
     pub p0_27: p0::P0_27<Disconnected>,
     pub p0_28: p0::P0_28<Disconnected>,
@@ -224,6 +234,23 @@ impl Into<twi::Pins> for I2CPins {
         twi::Pins {
             scl: self.scl.degrade(),
             sda: self.sda.degrade(),
+        }
+    }
+}
+
+/// UART to debugger pins
+pub struct UartPins {
+    tx: UART_TX,
+    rx: UART_RX,
+}
+
+impl Into<uart::Pins> for UartPins {
+    fn into(self) -> uart::Pins {
+        uart::Pins {
+            txd: self.tx.degrade(),
+            rxd: self.rx.degrade(),
+            cts: None,
+            rts: None,
         }
     }
 }

--- a/microbit-common/src/v2/board.rs
+++ b/microbit-common/src/v2/board.rs
@@ -192,8 +192,8 @@ impl Board {
                 sda: p1parts.p1_00.into_floating_input(),
             },
             uart: UartPins {
-                tx: p1parts.p1_08.into_push_pull_output(Level::Low),
-                rx: p0parts.p0_06.into_floating_input(),
+                tx: p0parts.p0_06.into_push_pull_output(Level::High),
+                rx: p1parts.p1_08.into_floating_input(),
             },
 
             // Core peripherals

--- a/microbit-common/src/v2/board.rs
+++ b/microbit-common/src/v2/board.rs
@@ -1,9 +1,8 @@
-use super::gpio::{DisplayPins, BTN_A, BTN_B, INT_SCL, INT_SDA, SCL, SDA, UART_TX, UART_RX};
+use super::gpio::{DisplayPins, BTN_A, BTN_B, INT_SCL, INT_SDA, SCL, SDA, UART_RX, UART_TX};
 use crate::{
     hal::{
         gpio::{p0, p1, Disconnected, Level},
-        twim, twis,
-        uarte,
+        twim, twis, uarte,
     },
     pac,
 };

--- a/microbit-common/src/v2/gpio.rs
+++ b/microbit-common/src/v2/gpio.rs
@@ -114,8 +114,8 @@ pub type SCL = p0::P0_26<Input<Floating>>;
 pub type SDA = p1::P1_00<Input<Floating>>;
 
 /* uart */
-pub type UART_TX = p1::P1_08<Output<PushPull>>;
-pub type UART_RX = p0::P0_06<Input<Floating>>;
+pub type UART_TX = p0::P0_06<Output<PushPull>>;
+pub type UART_RX = p1::P1_08<Input<Floating>>;
 
 /* speaker */
 pub type SPEAKER = p0::P0_00<Output<PushPull>>;

--- a/microbit/src/lib.rs
+++ b/microbit/src/lib.rs
@@ -14,22 +14,3 @@
 #![allow(non_camel_case_types)]
 
 pub use microbit_common::*;
-
-/// Create a [Uart](hal::uart::Uart) client with the default pins
-#[macro_export]
-macro_rules! serial_port {
-    ( $gpio:expr, $uart:expr, $speed:expr ) => {{
-        use microbit::hal::{gpio::Level, uart};
-
-        /* Configure RX and TX pins accordingly */
-        let pins = uart::Pins {
-            rxd: $gpio.p0_25.into_floating_input().degrade(),
-            txd: $gpio.p0_24.into_push_pull_output(Level::Low).degrade(),
-            cts: None,
-            rts: None,
-        };
-
-        /* Set up serial port using the prepared pins */
-        uart::Uart::new($uart, pins, uart::Parity::EXCLUDED, $speed)
-    }};
-}


### PR DESCRIPTION
This implements an abstraction for UARTE, very similar to the general I2C abstracttion. At the moment the example doesn't compile for nrf52833 yet, once https://github.com/nrf-rs/nrf-hal/pull/281 is finally merged that should be fairly trivial to do though.