### PR TITLE
Bump version to 0.11.0

### DIFF
--- a/.github/bors.toml
+++ b/.github/bors.toml
@@ -4,5 +4,5 @@ delete_merged_branches = true
 status = [
     "Rustfmt",
     "build (stable)",
-    "build (1.51.0)",
+    "build (1.53.0)",
 ]

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,7 +15,7 @@ jobs:
           - stable
           - beta
           - nightly
-          - 1.51.0  # Minimum supported rust version (MSRV)
+          - 1.53.0  # Minimum supported rust version (MSRV)
 
     steps:
       - uses: actions/checkout@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+(no changes)
+
+## [0.11.0] - 2021-09-13
+
 ### Added
 
 - Added support for the thumbv7em-none-eabi target for microbit:v2 (same as
@@ -48,7 +52,8 @@ Republished without changes to fix missing README.md in crates.io.
 - Fix rustdoc warnings
 - Upgrade nrf51-hal to 0.12.1
 
-[Unreleased]: https://github.com/nrf-rs/microbit/compare/v0.10.1...HEAD
+[Unreleased]: https://github.com/nrf-rs/microbit/compare/v0.11.0...HEAD
+[0.11.0]: https://github.com/nrf-rs/microbit/releases/tag/v0.10.1...v0.11.0
 [0.10.1]: https://github.com/nrf-rs/microbit/releases/tag/v0.10.0...v0.10.1
 [0.10.0]: https://github.com/nrf-rs/microbit/releases/tag/v0.9.0...v0.10.0
 [0.9.0]: https://github.com/nrf-rs/microbit/compare/v0.8.0...v0.9.0

--- a/microbit-common/Cargo.toml
+++ b/microbit-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "microbit-common"
-version = "0.10.1"
+version = "0.11.0"
 description = "Implementation details for the BBC Micro:bit board support crates"
 edition = "2018"
 readme = "../README.md"

--- a/microbit-common/src/lib.rs
+++ b/microbit-common/src/lib.rs
@@ -1,7 +1,7 @@
 //! microbit contains everything required to get started with the use of Rust
 //! to create firmwares for the fabulous [BBC micro:bit](https://microbit.org)
 //! microcontroller board.
-#![doc(html_root_url = "https://docs.rs/microbit-common/0.10.0")]
+#![doc(html_root_url = "https://docs.rs/microbit-common/0.11.0")]
 #![no_std]
 #![deny(missing_docs)]
 #![allow(non_camel_case_types)]

--- a/microbit-v2/Cargo.toml
+++ b/microbit-v2/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "microbit-v2"
-version = "0.10.1"
+version = "0.11.0"
 description = "Board support crate for the BBC Micro:bit V2"
 edition = "2018"
 readme = "../README.md"
@@ -33,4 +33,4 @@ path = "src/lib.rs"
 [dependencies.microbit-common]
 path = "../microbit-common"
 features = ["v2"]
-version = "=0.10.1"
+version = "=0.11.0"

--- a/microbit-v2/src/lib.rs
+++ b/microbit-v2/src/lib.rs
@@ -8,7 +8,7 @@
 //!
 //! [<img src="https://github.com/microbit-foundation/microbit-svg/raw/master/microbit-drawing-back-1-5.png" width="372px" height="300px">](https://github.com/microbit-foundation/microbit-svg/blob/master/microbit-drawing-back-1-5.png)
 //! [<img src="https://github.com/microbit-foundation/microbit-svg/raw/master/microbit-drawing-back-2.png" width="372px" height="300px">](https://github.com/microbit-foundation/microbit-svg/blob/master/microbit-drawing-back-2.png)
-#![doc(html_root_url = "https://docs.rs/microbit-v2/0.10.0")]
+#![doc(html_root_url = "https://docs.rs/microbit-v2/0.11.0")]
 #![no_std]
 #![deny(missing_docs)]
 #![allow(non_camel_case_types)]

--- a/microbit/Cargo.toml
+++ b/microbit/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "microbit"
-version = "0.10.1"
+version = "0.11.0"
 description = "Board support crate for the BBC Micro:bit V1"
 edition = "2018"
 readme = "../README.md"
@@ -29,4 +29,4 @@ license = "0BSD"
 [dependencies.microbit-common]
 path = "../microbit-common"
 features = ["v1"]
-version = "=0.10.1"
+version = "=0.11.0"

--- a/microbit/src/lib.rs
+++ b/microbit/src/lib.rs
@@ -8,7 +8,7 @@
 //!
 //! [<img src="https://github.com/microbit-foundation/microbit-svg/raw/master/microbit-drawing-back-1-5.png" width="372px" height="300px">](https://github.com/microbit-foundation/microbit-svg/blob/master/microbit-drawing-back-1-5.png)
 //! [<img src="https://github.com/microbit-foundation/microbit-svg/raw/master/microbit-drawing-back-2.png" width="372px" height="300px">](https://github.com/microbit-foundation/microbit-svg/blob/master/microbit-drawing-back-2.png)
-#![doc(html_root_url = "https://docs.rs/microbit/0.10.0")]
+#![doc(html_root_url = "https://docs.rs/microbit/0.11.0")]
 #![no_std]
 #![deny(missing_docs)]
 #![allow(non_camel_case_types)]


### PR DESCRIPTION
See: [CHANGELOG.md](/CHANGELOG.md)

### Added

- Added support for the thumbv7em-none-eabi target for microbit:v2 (same as
  thumbv7em-none-eabihf but without hardware floating point support)

### Changed

- Rearrange LED display modules under the same root module and change their
  APIs to be more aligned with each other.
- Add BLE Beacon demo.
- Add a simple speaker demo for micro:bit V2.
- Add Board struct following the pattern used in other nrf board support crates.
- Add magnetometer example.
- LEDs on the micro:bit V1 are now turned off per default
- UART(E) is now exposed in the same way as I2C
