### PR TITLE
Fix issue with version number in bors config

### DIFF
--- a/.github/bors.toml
+++ b/.github/bors.toml
@@ -4,5 +4,5 @@ delete_merged_branches = true
 status = [
     "Rustfmt",
     "build (stable)",
-    "build (1.53.0)",
+    "build (MSRV)",
 ]

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,7 +15,12 @@ jobs:
           - stable
           - beta
           - nightly
-          - 1.53.0  # Minimum supported rust version (MSRV)
+        include:
+          # Minimum supported rust version (MSRV)
+          - name: MSRV
+            rust: 1.53.0
+
+    name: "build (${{ matrix.name || matrix.rust }})"
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
This change fixes the issue where bors times out waiting for a build that does not exist whenever we change the MSRV.

See [this comment](https://github.com/nrf-rs/microbit/pull/64#issuecomment-918124858)