### PR TITLE
Bump hal versions to 0.14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
-(no changes)
+### Changed
+- Upgraded nrf-hals to 0.14
 
 ## [0.11.0] - 2021-09-13
 

--- a/microbit-common/Cargo.toml
+++ b/microbit-common/Cargo.toml
@@ -25,17 +25,16 @@ keywords = [
 license = "0BSD"
 
 [dependencies]
-tiny-led-matrix = "1.0.1"
-embedded-hal = "0.2.4"
+tiny-led-matrix = "1.0"
+embedded-hal = "0.2"
 
 [dependencies.nrf51-hal]
 optional = true
-version = "0.13.0"
+version = "0.14"
 
 [dependencies.nrf52833-hal]
 optional = true
-version = "0.13.0"
-git = "https://github.com/nrf-rs/nrf-hal"
+version = "0.14"
 
 [features]
 doc = []


### PR DESCRIPTION
⚠️ This does not currently work ⚠️ 
I'm leaving this open as somewhere to track progress.

- Bump nrf-hal to 0.14
- Loosen dependency requirements so that we don't pin to a specific patch version. Pinning that specifically means the user is more likely to end up with multiple versions of each crate.