### PR TITLE
Update HAL versions

### DIFF
--- a/microbit-common/Cargo.toml
+++ b/microbit-common/Cargo.toml
@@ -30,12 +30,11 @@ embedded-hal = "0.2.4"
 
 [dependencies.nrf51-hal]
 optional = true
-version = "0.13.0"
+version = "0.14.0"
 
 [dependencies.nrf52833-hal]
 optional = true
-version = "0.13.0"
-git = "https://github.com/nrf-rs/nrf-hal"
+version = "0.14.0"
 
 [features]
 doc = []


### PR DESCRIPTION
Update the nrf51 and 52833 HAL since nrf-hal made a release.

Note that since we are pulling in a git version of nrf52833 HAL at the
moment the build is in fact broken without this PR.

Also since the HALs made a release now maybe it's time to make a
release here as well? That way I could also remove the git dependencies
from the discovery book so the build is more stable and doesn't break because
of stuff like this in the future.