### PR TITLE
Update nrf-hal dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
-(no changes)
+### Changed
+
+- Update dependencies nrf51-hal and nrf52833-hal to 0.14.0
 
 ## [0.11.0] - 2021-09-13
 

--- a/examples/ble-beacon/Cargo.toml
+++ b/examples/ble-beacon/Cargo.toml
@@ -9,8 +9,8 @@ cortex-m-rt = "0.6.12"
 panic-halt = "0.2.0"
 defmt-rtt = "0.2.0"
 defmt = "0.2.0"
-rubble = "0.0.4"
-rubble-nrf5x = { version = "0.0.4", default-features = false }
+rubble = { version = "0.0.4", git = "https://github.com/jonas-schievink/rubble" }
+rubble-nrf5x = { version = "0.0.4", default-features = false, git = "https://github.com/jonas-schievink/rubble" }
 
 [dependencies.microbit]
 path = "../../microbit"

--- a/examples/display-nonblocking/Cargo.toml
+++ b/examples/display-nonblocking/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-cortex-m = "0.6.1"
+cortex-m = "0.7.3"
 cortex-m-rt = "0.6.12"
 panic-halt = "0.2.0"
 defmt-rtt = "0.2.0"

--- a/examples/display-rtic/Cargo.toml
+++ b/examples/display-rtic/Cargo.toml
@@ -4,10 +4,11 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
+cortex-m = "0.7.3"
 panic-halt = "0.2.0"
 defmt-rtt = "0.2.0"
 defmt = "0.2.0"
-cortex-m-rtic = "0.5"
+cortex-m-rtic = { version = "0.5", default-features = false, features = ["cortex-m-7"] }
 
 [dependencies.microbit]
 path = "../../microbit"

--- a/microbit-common/Cargo.toml
+++ b/microbit-common/Cargo.toml
@@ -30,12 +30,11 @@ embedded-hal = "0.2.4"
 
 [dependencies.nrf51-hal]
 optional = true
-version = "0.13.0"
+version = "0.14.0"
 
 [dependencies.nrf52833-hal]
 optional = true
-version = "0.13.0"
-git = "https://github.com/nrf-rs/nrf-hal"
+version = "0.14.0"
 
 [features]
 doc = []


### PR DESCRIPTION
The unreleased fix is now released in 0.14.0 so pulling 0.13.0 from git is no longer needed (and no longer works without pinning to a commit).

However, this changes the `cortex-m` version from 0.6.x to 0.7.3 which causes problems for some of the examples where the old `cortex-m` is still brought in by other dependencies. The fix for the `display-rtic` example is to use the `cortex-m-7` feature until `cortex-m-rtic` 0.6 is released. For `rubble` the only fix I could find was to grab the git version as it does use the latest `nrf5x` pac there it's just not released yet.