### PR TITLE
Add temp peripheral to board

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 
 - Update dependencies nrf51-hal and nrf52833-hal to 0.14.0
+- Added TEMP field to board
 
 ## [0.11.0] - 2021-09-13
 

--- a/microbit-common/src/v1/board.rs
+++ b/microbit-common/src/v1/board.rs
@@ -76,7 +76,8 @@ pub struct Board {
     /// nRF51 peripheral: RTC0
     pub RTC0: pac::RTC0,
 
-    /// nRF51 peripheral: TEMP
+    /// nRF51 peripheral: TEMP <br>
+    /// Can be used with [`Temp::new()`](`crate::hal::temp::Temp::new()`)
     pub TEMP: pac::TEMP,
 
     /// nRF51 peripheral: TIMER0

--- a/microbit-common/src/v1/board.rs
+++ b/microbit-common/src/v1/board.rs
@@ -76,6 +76,9 @@ pub struct Board {
     /// nRF51 peripheral: RTC0
     pub RTC0: pac::RTC0,
 
+    /// nRF51 peripheral: TEMP
+    pub TEMP: pac::TEMP,
+
     /// nRF51 peripheral: TIMER0
     pub TIMER0: pac::TIMER0,
 
@@ -169,6 +172,7 @@ impl Board {
             RADIO: p.RADIO,
             RNG: p.RNG,
             RTC0: p.RTC0,
+            TEMP: p.TEMP,
             TIMER0: p.TIMER0,
             TIMER1: p.TIMER1,
             TIMER2: p.TIMER2,

--- a/microbit-common/src/v2/board.rs
+++ b/microbit-common/src/v2/board.rs
@@ -97,6 +97,9 @@ pub struct Board {
     /// nRF52 peripheral: RTC0
     pub RTC0: pac::RTC0,
 
+    /// nRF52 peripheral: TEMP
+    pub TEMP: pac::TEMP,
+
     /// nRF52 peripheral: TIMER0
     pub TIMER0: pac::TIMER0,
 
@@ -221,6 +224,7 @@ impl Board {
             RADIO: p.RADIO,
             RNG: p.RNG,
             RTC0: p.RTC0,
+            TEMP: p.TEMP,
             TIMER0: p.TIMER0,
             TIMER1: p.TIMER1,
             TIMER2: p.TIMER2,

--- a/microbit-common/src/v2/board.rs
+++ b/microbit-common/src/v2/board.rs
@@ -97,7 +97,8 @@ pub struct Board {
     /// nRF52 peripheral: RTC0
     pub RTC0: pac::RTC0,
 
-    /// nRF52 peripheral: TEMP
+    /// nRF52 peripheral: TEMP <br>
+    /// Can be used with [`Temp::new()`](`crate::hal::temp::Temp::new()`)
     pub TEMP: pac::TEMP,
 
     /// nRF52 peripheral: TIMER0


### PR DESCRIPTION
I needed to use board features as well as the cpu temp that was currently only available from the peripherals. 

I would prefer to even include it in the board directly similar to the buttons or add a function to the board the returns the temp struct to make it more simple to use. Is this an desired improvement or too much bloat?