### PR TITLE
Fix wrong order of display columns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Update dependencies nrf51-hal and nrf52833-hal to 0.14.0
 - Added TEMP field to board
+- Fixed Issue where columns 2,3 and 4 of the nonblocking display were swapped
 
 ## [0.11.0] - 2021-09-13
 

--- a/microbit-common/src/display/nonblocking/control.rs
+++ b/microbit-common/src/display/nonblocking/control.rs
@@ -31,8 +31,7 @@ mod pins {
 #[cfg(feature = "v2")]
 mod pins {
     use super::{NUM_COLS, NUM_ROWS};
-    // WTF!? this should be [28, 11, 31, 30] but cols 2 & 3 are swapped
-    pub(super) const P0_COLS: [usize; NUM_COLS - 1] = [28, 31, 11, 30];
+    pub(super) const P0_COLS: [usize; NUM_COLS - 1] = [28, 11, 31, 30];
     pub(super) const P1_COLS: [usize; 1] = [5];
 
     pub(super) const P0_ROWS: [usize; NUM_ROWS] = [21, 22, 15, 24, 19];
@@ -75,10 +74,10 @@ fn split_cols(cols: u32) -> (u32, u32) {
 
 #[cfg(feature = "v2")]
 fn split_cols(cols: u32) -> (u32, u32) {
-    // get all except col 4 (2nd from least significant)
-    let p0_cols = ((cols >> 2) << 1) | (1 & cols);
-    // get col 4 (2nd from least significant)
-    let p1_cols = (cols >> 1) & 1;
+    // get all except col 2 (4th from least significant)
+    let p0_cols = ((cols & 0b10000) >> 1) | (0b00111 & cols);
+    // get col 4 (4th from least significant)
+    let p1_cols = (cols & 0b01000) >> 3;
     (p0_cols, p1_cols)
 }
 


### PR DESCRIPTION
Currently when cycling through the outer leds of the display in the nonblocking mode the order is broken for the top & bottom row. The current order is 1->4->3->2->5.
This PR fixes the issue some of the columns were mixed up and matches with the docs from the microbit.
It can be tested by replacing the display_nonblocking example with the slightly modified example here: https://gist.github.com/7b8d71b6b06eb8ab11a5f5f0a13f7a47