### PR TITLE
Make `Board::new(p, cp)` pub and fix RTIC example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
-(no changes)
+- Make `Board::new(p, cp)` public and fix RTIC example
 
 ## [0.12.0] - 2021-11-10
 

--- a/examples/display-rtic/src/main.rs
+++ b/examples/display-rtic/src/main.rs
@@ -33,7 +33,7 @@ fn heart_image(inner_brightness: u8) -> GreyscaleImage {
     ])
 }
 
-#[app(device = microbit::pac, peripherals = false)]
+#[app(device = microbit::pac, peripherals = true)]
 const APP: () = {
     struct Resources {
         display: Display<pac::TIMER1>,
@@ -41,8 +41,8 @@ const APP: () = {
     }
 
     #[init]
-    fn init(_cx: init::Context) -> init::LateResources {
-        let board = Board::take().unwrap();
+    fn init(cx: init::Context) -> init::LateResources {
+        let board = Board::new(cx.device, cx.core);
 
         // Starting the low-frequency clock (needed for RTC to work)
         Clocks::new(board.CLOCK).start_lfclk();

--- a/microbit-common/src/v1/board.rs
+++ b/microbit-common/src/v1/board.rs
@@ -117,7 +117,7 @@ impl Board {
     /// return an instance of the board.
     ///
     /// An exemplary usecase is shown in the rtic display example.
-    fn new(p: pac::Peripherals, cp: pac::CorePeripherals) -> Self {
+    pub fn new(p: pac::Peripherals, cp: pac::CorePeripherals) -> Self {
         let p0parts = p0::Parts::new(p.GPIO);
         Self {
             pins: Pins {

--- a/microbit-common/src/v1/board.rs
+++ b/microbit-common/src/v1/board.rs
@@ -101,6 +101,8 @@ impl Board {
     ///
     /// This method will return an instance of the board the first time it is
     /// called. It will return only `None` on subsequent calls.
+    /// This function can also return `None` if one of the the peripherals was
+    /// already taken.
     pub fn take() -> Option<Self> {
         Some(Self::new(
             pac::Peripherals::take()?,
@@ -108,6 +110,13 @@ impl Board {
         ))
     }
 
+    /// Fallback method in the case peripherals and core peripherals were taken
+    /// elsewhere already.
+    ///
+    /// This method will take the peripherals and core peripherals and
+    /// return an instance of the board.
+    ///
+    /// An exemplary usecase is shown in the rtic display example.
     fn new(p: pac::Peripherals, cp: pac::CorePeripherals) -> Self {
         let p0parts = p0::Parts::new(p.GPIO);
         Self {

--- a/microbit-common/src/v2/board.rs
+++ b/microbit-common/src/v2/board.rs
@@ -145,10 +145,10 @@ impl Board {
 
     /// Fallback method in the case peripherals and core peripherals were taken
     /// elsewhere already.
-    /// 
+    ///
     /// This method will take the peripherals and core peripherals and
-    /// return an instance of the board. 
-    /// 
+    /// return an instance of the board.
+    ///
     /// An exemplary usecase is shown in the rtic display example.
     pub fn new(p: pac::Peripherals, cp: pac::CorePeripherals) -> Self {
         let p0parts = p0::Parts::new(p.P0);

--- a/microbit-common/src/v2/board.rs
+++ b/microbit-common/src/v2/board.rs
@@ -134,6 +134,8 @@ impl Board {
     ///
     /// This method will return an instance of the board the first time it is
     /// called. It will return only `None` on subsequent calls.
+    /// This function can also return `None` if one of the the peripherals was
+    /// already taken.
     pub fn take() -> Option<Self> {
         Some(Self::new(
             pac::Peripherals::take()?,
@@ -141,7 +143,14 @@ impl Board {
         ))
     }
 
-    fn new(p: pac::Peripherals, cp: pac::CorePeripherals) -> Self {
+    /// Fallback method in the case peripherals and core peripherals were taken
+    /// elsewhere already.
+    /// 
+    /// This method will take the peripherals and core peripherals and
+    /// return an instance of the board. 
+    /// 
+    /// An exemplary usecase is shown in the rtic display example.
+    pub fn new(p: pac::Peripherals, cp: pac::CorePeripherals) -> Self {
         let p0parts = p0::Parts::new(p.P0);
         let p1parts = p1::Parts::new(p.P1);
         Self {


### PR DESCRIPTION
Fixes #73 thanks to the help of @korken89 in the rtic matrix.

RTIC takes the core peripherals already for its own context. There board should take these directly from the context for its own creation.
