### PR TITLE
Fix timer for LED-display (GreyscaleImage with a empty Row did not work)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 
 - Fix display-nonblocking example
+- Fix timer for LED-display (GreyscaleImage with a empty Row did not work)
 
 ## [0.12.0] - 2021-11-10
 

--- a/microbit-common/src/display/nonblocking/timer.rs
+++ b/microbit-common/src/display/nonblocking/timer.rs
@@ -66,11 +66,10 @@ impl<T: Instance> DisplayTimer for MicrobitDisplayTimer<T> {
     }
 
     fn disable_secondary(&mut self) {
-        // TODO: is this clear or clear_bit?
         self.0
             .as_timer0()
-            .intenset
-            .write(|w| w.compare0().clear_bit());
+            .intenclr
+            .write(|w| w.compare1().set_bit());
     }
 
     fn program_secondary(&mut self, ticks: u16) {


### PR DESCRIPTION
The ```fn disable_secondary(&mut self) ``` function for the display timer did not work. This caused a crash when a GrayScaleImage had a row with just 0-Values.