### PR TITLE
Add an example of scrolling text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+- Add display-text-rtic example
 - Make `Board::new(p, cp)` public and fix RTIC example
 - Fix display-nonblocking example
 - Fix timer for LED-display (GreyscaleImage with a empty Row did not work)

--- a/examples/display-text-rtic/Cargo.toml
+++ b/examples/display-text-rtic/Cargo.toml
@@ -1,0 +1,36 @@
+[package]
+name = "display-text-rtic"
+version = "0.1.0"
+edition = "2018"
+
+[dependencies]
+cortex-m = "0.7.3"
+panic-halt = "0.2.0"
+defmt-rtt = "0.2.0"
+defmt = "0.2.0"
+cortex-m-rtic = { version = "0.5", default-features = false, features = ["cortex-m-7"] }
+microbit-text = "0.1.0"
+
+[dependencies.microbit]
+path = "../../microbit"
+optional = true
+
+[dependencies.microbit-v2]
+path = "../../microbit-v2"
+optional = true
+
+[features]
+v1 = ["microbit"]
+v2 = ["microbit-v2"]
+
+default = [
+  "defmt-default",
+]
+
+# do NOT modify these features
+defmt-default = []
+defmt-trace = []
+defmt-debug = []
+defmt-info = []
+defmt-warn = []
+defmt-error = []

--- a/examples/display-text-rtic/Cargo.toml
+++ b/examples/display-text-rtic/Cargo.toml
@@ -9,7 +9,7 @@ panic-halt = "0.2.0"
 defmt-rtt = "0.2.0"
 defmt = "0.2.0"
 cortex-m-rtic = { version = "0.5", default-features = false, features = ["cortex-m-7"] }
-microbit-text = "0.1.0"
+microbit-text = "1.0.0"
 
 [dependencies.microbit]
 path = "../../microbit"

--- a/examples/display-text-rtic/src/main.rs
+++ b/examples/display-text-rtic/src/main.rs
@@ -1,0 +1,78 @@
+//! An example of scrolling static text.
+//!
+//! It uses `TIMER1` to drive the display, and `RTC0` to animate the text.
+#![no_main]
+#![no_std]
+
+use defmt_rtt as _;
+use panic_halt as _;
+
+use microbit::{
+    board::Board,
+    display::nonblocking::{Display, Frame, MicrobitFrame},
+    hal::{
+        clocks::Clocks,
+        rtc::{Rtc, RtcInterrupt},
+    },
+    pac,
+};
+use microbit_text::scrolling::Animate;
+use microbit_text::scrolling_text::ScrollingStaticText;
+
+use rtic::app;
+
+const MESSAGE: &[u8] = b"Hello, world!";
+
+#[app(device = microbit::pac, peripherals = true)]
+const APP: () = {
+    struct Resources {
+        display: Display<pac::TIMER1>,
+        anim_timer: Rtc<pac::RTC0>,
+        scroller: ScrollingStaticText,
+    }
+
+    #[init]
+    fn init(cx: init::Context) -> init::LateResources {
+        let board = Board::new(cx.device, cx.core);
+
+        // Starting the low-frequency clock (needed for RTC to work)
+        Clocks::new(board.CLOCK).start_lfclk();
+
+        // RTC at 16Hz (32_768 / (2047 + 1))
+        // 16Hz; 62.5ms period
+        let mut rtc0 = Rtc::new(board.RTC0, 2047).unwrap();
+        rtc0.enable_event(RtcInterrupt::Tick);
+        rtc0.enable_interrupt(RtcInterrupt::Tick, None);
+        rtc0.enable_counter();
+
+        let display = Display::new(board.TIMER1, board.display_pins);
+
+        let mut scroller = ScrollingStaticText::default();
+        scroller.set_message(MESSAGE);
+
+        init::LateResources {
+            anim_timer: rtc0,
+            display,
+            scroller,
+        }
+    }
+
+    #[task(binds = TIMER1, priority = 2, resources = [display])]
+    fn timer1(cx: timer1::Context) {
+        cx.resources.display.handle_display_event();
+    }
+
+    #[task(binds = RTC0, priority = 1,
+           resources = [anim_timer, display, scroller])]
+    fn rtc0(mut cx: rtc0::Context) {
+        static mut FRAME: MicrobitFrame = MicrobitFrame::default();
+        cx.resources.anim_timer.reset_event(RtcInterrupt::Tick);
+        if !cx.resources.scroller.is_finished() {
+            cx.resources.scroller.tick();
+            FRAME.set(cx.resources.scroller);
+            cx.resources.display.lock(|display| {
+                display.show_frame(FRAME);
+            });
+        }
+    }
+};


### PR DESCRIPTION
The implementation is in a separate [`microbit-text`] crate as discussed in #78.

I've tested on micro:bit v1 only.

I did the example using RTIC, but I can just as easily do it without (or both ways).

Does this look sensible? If everyone's happy with `microbit-text` as it stands I can make it v1.0.0.

[`microbit-text`]: https://github.com/mattheww/microbit-text
