### PR TITLE
Run clippy against main packages

### DIFF
--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -15,7 +15,15 @@ jobs:
           toolchain: stable
           target: thumbv6m-none-eabi
           override: true
-      - uses: actions-rs/clippy-check@v1
+
+      - name: microbit V1
+        uses: actions-rs/clippy-check@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          args: --examples -- -D warnings
+          args: --package microbit -- -D warnings
+
+      - name: microbit V2
+        uses: actions-rs/clippy-check@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          args: --package microbit-v2 -- -D warnings

--- a/microbit-common/src/v1/board.rs
+++ b/microbit-common/src/v1/board.rs
@@ -242,11 +242,11 @@ pub struct I2CPins {
     sda: SDA,
 }
 
-impl Into<twi::Pins> for I2CPins {
-    fn into(self) -> twi::Pins {
-        twi::Pins {
-            scl: self.scl.degrade(),
-            sda: self.sda.degrade(),
+impl From<I2CPins> for twi::Pins {
+    fn from(pins: I2CPins) -> Self {
+        Self {
+            scl: pins.scl.degrade(),
+            sda: pins.sda.degrade(),
         }
     }
 }
@@ -257,11 +257,11 @@ pub struct UartPins {
     rx: UART_RX,
 }
 
-impl Into<uart::Pins> for UartPins {
-    fn into(self) -> uart::Pins {
-        uart::Pins {
-            txd: self.tx.degrade(),
-            rxd: self.rx.degrade(),
+impl From<UartPins> for uart::Pins {
+    fn from(pins: UartPins) -> Self {
+        Self {
+            rxd: pins.rx.degrade(),
+            txd: pins.tx.degrade(),
             cts: None,
             rts: None,
         }

--- a/microbit-common/src/v2/board.rs
+++ b/microbit-common/src/v2/board.rs
@@ -322,20 +322,20 @@ pub struct I2CInternalPins {
     sda: INT_SDA,
 }
 
-impl Into<twim::Pins> for I2CInternalPins {
-    fn into(self) -> twim::Pins {
-        twim::Pins {
-            scl: self.scl.degrade(),
-            sda: self.sda.degrade(),
+impl From<I2CInternalPins> for twim::Pins {
+    fn from(pins: I2CInternalPins) -> Self {
+        Self {
+            scl: pins.scl.degrade(),
+            sda: pins.sda.degrade(),
         }
     }
 }
 
-impl Into<twis::Pins> for I2CInternalPins {
-    fn into(self) -> twis::Pins {
-        twis::Pins {
-            scl: self.scl.degrade(),
-            sda: self.sda.degrade(),
+impl From<I2CInternalPins> for twis::Pins {
+    fn from(pins: I2CInternalPins) -> Self {
+        Self {
+            scl: pins.scl.degrade(),
+            sda: pins.sda.degrade(),
         }
     }
 }
@@ -346,20 +346,20 @@ pub struct I2CExternalPins {
     sda: SDA,
 }
 
-impl Into<twim::Pins> for I2CExternalPins {
-    fn into(self) -> twim::Pins {
-        twim::Pins {
-            scl: self.scl.degrade(),
-            sda: self.sda.degrade(),
+impl From<I2CExternalPins> for twim::Pins {
+    fn from(pins: I2CExternalPins) -> Self {
+        Self {
+            scl: pins.scl.degrade(),
+            sda: pins.sda.degrade(),
         }
     }
 }
 
-impl Into<twis::Pins> for I2CExternalPins {
-    fn into(self) -> twis::Pins {
-        twis::Pins {
-            scl: self.scl.degrade(),
-            sda: self.sda.degrade(),
+impl From<I2CExternalPins> for twis::Pins {
+    fn from(pins: I2CExternalPins) -> Self {
+        Self {
+            scl: pins.scl.degrade(),
+            sda: pins.sda.degrade(),
         }
     }
 }
@@ -370,11 +370,11 @@ pub struct UartPins {
     rx: UART_RX,
 }
 
-impl Into<uarte::Pins> for UartPins {
-    fn into(self) -> uarte::Pins {
-        uarte::Pins {
-            txd: self.tx.degrade(),
-            rxd: self.rx.degrade(),
+impl From<UartPins> for uarte::Pins {
+    fn from(pins: UartPins) -> Self {
+        Self {
+            txd: pins.tx.degrade(),
+            rxd: pins.rx.degrade(),
             cts: None,
             rts: None,
         }


### PR DESCRIPTION
The `--examples` flag is no longer working. It has been silently failing since the examples moved to full crates rather modules.