### PR TITLE
Bump MSRV to 1.57

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,8 +17,10 @@ jobs:
           - nightly
         include:
           # Minimum supported rust version (MSRV)
+          # Note this needs to be new enough to build the examples as well as
+          # the library itself.
           - name: MSRV
-            rust: 1.53.0
+            rust: 1.56.0
 
     name: "build (${{ matrix.name || matrix.rust }})"
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,7 +20,7 @@ jobs:
           # Note this needs to be new enough to build the examples as well as
           # the library itself.
           - name: MSRV
-            rust: 1.56.0
+            rust: 1.57.0
 
     name: "build (${{ matrix.name || matrix.rust }})"
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+- Increase minimum supported Rust version to 1.57
 - Add display-text-rtic example
 - Make `Board::new(p, cp)` public and fix RTIC example
 - Fix display-nonblocking example


### PR DESCRIPTION
This will let us use dependencies that need Rust 2021 in examples.

As discussed at https://github.com/nrf-rs/microbit/pull/80#issuecomment-977001166 and https://github.com/nrf-rs/microbit/pull/83#issuecomment-1035592387 .
