### PR TITLE
Fix ci by bumbing msrv to 1.61

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,7 +20,7 @@ jobs:
           # Note this needs to be new enough to build the examples as well as
           # the library itself.
           - name: MSRV
-            rust: 1.57.0
+            rust: 1.61.0
 
     name: "build (${{ matrix.name || matrix.rust }})"
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 
 - Update examples to use RTIC 1.0
+- Increase MSRV to 1.61
 
 ## [0.13.0] - 2022-05-24
 

--- a/microbit-common/Cargo.toml
+++ b/microbit-common/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.13.0"
 description = "Implementation details for the BBC Micro:bit board support crates"
 edition = "2018"
 readme = "../README.md"
+rust-version = "1.61"
 
 repository = "https://github.com/nrf-rs/microbit"
 authors = [


### PR DESCRIPTION
Fixed released an update and now requires rust 1.61 (https://crates.io/crates/fixed)