### PR TITLE
Unify names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Add analog example
 - Increase minimum supported Rust version to 1.57
 - Added support for the real time counters RTC1 and RTC2
+- Add common types and structs for the edge connector pads and pins
+- Add common ADC types and initialization for ADC and SAADC
+- Common ADC example
+- Add support for PPI
+- Servo example using TIMER, GPIOTE and PPI
 
 ## [0.13.0] - 2022-05-24
 

--- a/examples/analog-v1/src/main.rs
+++ b/examples/analog-v1/src/main.rs
@@ -18,7 +18,7 @@ fn main() -> ! {
         let mut timer = Timer::new(board.TIMER0);
         let mut display = Display::new(board.display_pins);
         let mut adc: Adc = Adc::new(board.ADC, AdcConfig::default());
-        let mut anapin = board.pins.p0_03.into_floating_input(); // PAD1
+        let mut anapin = board.edge.e00.into_floating_input(); // PAD1
 
         let numbers = [
             [

--- a/examples/analog-v2/src/main.rs
+++ b/examples/analog-v2/src/main.rs
@@ -17,8 +17,8 @@ fn main() -> ! {
     if let Some(board) = Board::take() {
         let mut timer = Timer::new(board.TIMER0);
         let mut display = Display::new(board.display_pins);
-        let mut adc: Saadc = Saadc::new(board.SAADC, SaadcConfig::default());
-        let mut anapin = board.pins.p0_03.into_floating_input(); // PAD1
+        let mut adc: Saadc = Saadc::new(board.ADC, SaadcConfig::default());
+        let mut anapin = board.edge.e00.into_floating_input(); // PAD1
 
         let numbers = [
             [

--- a/examples/analog/Cargo.toml
+++ b/examples/analog/Cargo.toml
@@ -1,0 +1,37 @@
+[package]
+name = "analog"
+version = "0.1.0"
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+cortex-m = { version = "0.7.3", features = ["critical-section-single-core"]}
+cortex-m-rt = "0.7"
+panic-halt = "0.2.0"
+defmt-rtt = "0.3.2"
+defmt = "0.3.1"
+
+[dependencies.microbit]
+path = "../../microbit"
+optional = true
+
+[dependencies.microbit-v2]
+path = "../../microbit-v2"
+optional = true
+
+[features]
+v1 = ["microbit"]
+v2 = ["microbit-v2"]
+
+default = [
+  "defmt-default",
+]
+
+# do NOT modify these features
+defmt-default = []
+defmt-trace = []
+defmt-debug = []
+defmt-info = []
+defmt-warn = []
+defmt-error = []

--- a/examples/analog/src/main.rs
+++ b/examples/analog/src/main.rs
@@ -1,0 +1,101 @@
+#![no_std]
+#![no_main]
+
+use defmt_rtt as _;
+use panic_halt as _;
+
+use cortex_m_rt::entry;
+
+use microbit::{
+    adc::{Adc, AdcConfig, Default},
+    board::Board,
+    display::blocking::Display,
+    hal::{prelude::*, Timer},
+};
+
+#[entry]
+fn main() -> ! {
+    if let Some(board) = Board::take() {
+        let mut timer = Timer::new(board.TIMER0);
+        let mut display = Display::new(board.display_pins);
+        let mut adc = Adc::new(board.ADC, AdcConfig::default_10bit());
+        let mut anapin = board.edge.e00.into_floating_input(); // PAD0
+
+        let numbers = [
+            [
+                [0, 0, 1, 0, 0],
+                [0, 1, 0, 1, 0],
+                [0, 1, 0, 1, 0],
+                [0, 1, 0, 1, 0],
+                [0, 0, 1, 0, 0],
+            ],
+            [
+                [0, 0, 1, 0, 0],
+                [0, 1, 1, 0, 0],
+                [0, 0, 1, 0, 0],
+                [0, 0, 1, 0, 0],
+                [0, 0, 1, 0, 0],
+            ],
+            [
+                [0, 0, 1, 0, 0],
+                [0, 1, 0, 1, 0],
+                [0, 0, 1, 0, 0],
+                [0, 1, 0, 0, 0],
+                [0, 1, 1, 1, 0],
+            ],
+            [
+                [0, 1, 1, 0, 0],
+                [0, 0, 0, 1, 0],
+                [0, 0, 1, 0, 0],
+                [0, 0, 0, 1, 0],
+                [0, 1, 1, 0, 0],
+            ],
+            [
+                [0, 1, 0, 0, 0],
+                [1, 0, 0, 0, 0],
+                [1, 0, 1, 0, 0],
+                [1, 1, 1, 1, 0],
+                [0, 0, 1, 0, 0],
+            ],
+        ];
+
+        let sign_plus = [
+            [0, 0, 1, 0, 0],
+            [0, 0, 1, 0, 0],
+            [1, 1, 1, 1, 1],
+            [0, 0, 1, 0, 0],
+            [0, 0, 1, 0, 0],
+        ];
+
+        #[allow(non_snake_case)]
+        let letter_E = [
+            [0, 1, 1, 1, 0],
+            [0, 1, 0, 0, 0],
+            [0, 1, 1, 0, 0],
+            [0, 1, 0, 0, 0],
+            [0, 1, 1, 1, 0],
+        ];
+
+        loop {
+            let analog = adc.read(&mut anapin);
+            match analog {
+                Ok(v) => {
+                    let n_iter = numbers.iter();
+                    let mut count: usize = 0;
+                    for n_val in n_iter {
+                        if count == usize::from(i16::unsigned_abs(v / 100)) {
+                            display.show(&mut timer, *n_val, 10);
+                            break;
+                        }
+                        count += 1;
+                    }
+                    if count == numbers.len() {
+                        display.show(&mut timer, sign_plus, 10);
+                    }
+                }
+                Err(_e) => display.show(&mut timer, letter_E, 10),
+            }
+        }
+    }
+    panic!("End");
+}

--- a/examples/servo/Cargo.toml
+++ b/examples/servo/Cargo.toml
@@ -1,0 +1,37 @@
+[package]
+name = "servo"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+cortex-m = { version = "0.7.7", features = ["critical-section-single-core"]}
+cortex-m-rt = "0.7"
+panic-halt = "0.2.0"
+defmt-rtt = "0.3.2"
+defmt = "0.3.1"
+
+[dependencies.microbit]
+path = "../../microbit"
+optional = true
+
+[dependencies.microbit-v2]
+path = "../../microbit-v2"
+optional = true
+
+[features]
+v1 = ["microbit"]
+v2 = ["microbit-v2"]
+
+default = [
+  "defmt-default",
+]
+
+# do NOT modify these features
+defmt-default = []
+defmt-trace = []
+defmt-debug = []
+defmt-info = []
+defmt-warn = []
+defmt-error = []

--- a/examples/servo/src/main.rs
+++ b/examples/servo/src/main.rs
@@ -1,0 +1,122 @@
+#![no_std]
+#![no_main]
+
+use defmt_rtt as _;
+use panic_halt as _;
+
+use core::cell::RefCell;
+use cortex_m::interrupt::Mutex;
+use cortex_m_rt::entry;
+
+use microbit::{
+    board::Board,
+    hal::{
+        gpio::Level,
+        gpiote::*,
+        pac::{self, interrupt, TIMER0},
+        ppi::{self, ConfigurablePpi, Ppi},
+    },
+};
+
+static SERVO_TIMER: Mutex<RefCell<Option<TIMER0>>> = Mutex::new(RefCell::new(None));
+
+#[entry]
+fn main() -> ! {
+    if let Some(board) = Board::take() {
+        let gpiote = Gpiote::new(board.GPIOTE);
+        // Servo output pins
+        #[cfg(feature = "v1")]
+        let servopin1 = board.pins.p0_01.into_push_pull_output(Level::Low).degrade(); // PAD3
+        #[cfg(feature = "v1")]
+        let servopin2 = board.pins.p0_02.into_push_pull_output(Level::Low).degrade(); // PAD2
+        
+        #[cfg(feature = "v2")]
+        let servopin1 = board.pins.p0_03.into_push_pull_output(Level::Low).degrade(); // PAD2
+        #[cfg(feature = "v2")]
+        let servopin2 = board.pins.p0_04.into_push_pull_output(Level::Low).degrade(); // PAD3
+        
+        // Output channel for Servo 1
+        gpiote
+            .channel0()
+            .output_pin(servopin1)
+            .task_out_polarity(TaskOutPolarity::Toggle)
+            .init_low();
+        gpiote.channel0().task_out().write(|w| unsafe { w.bits(1) });
+        // Output channel for Servo 2
+        gpiote
+            .channel1()
+            .output_pin(servopin2)
+            .task_out_polarity(TaskOutPolarity::Toggle)
+            .init_low();
+        gpiote.channel1().task_out().write(|w| unsafe { w.bits(1) });
+
+        let ppi_channels = ppi::Parts::new(board.PPI);
+        // Set both servo outputs high form Timer0 CC[0]
+        // Set each servo output low from the respective Timer0 CC[1] and CC[2]
+        // Each timer can run 3 Servos
+        let mut ppi0 = ppi_channels.ppi0;
+        ppi0.set_task_endpoint(gpiote.channel0().task_out());
+        ppi0.set_event_endpoint(&board.TIMER0.events_compare[0]);
+        ppi0.enable();
+        let mut ppi1 = ppi_channels.ppi1;
+        ppi1.set_task_endpoint(gpiote.channel0().task_out());
+        ppi1.set_event_endpoint(&board.TIMER0.events_compare[1]);
+        ppi1.enable();
+        let mut ppi2 = ppi_channels.ppi2;
+        ppi2.set_task_endpoint(gpiote.channel1().task_out());
+        ppi2.set_event_endpoint(&board.TIMER0.events_compare[0]);
+        ppi2.enable();
+        let mut ppi3 = ppi_channels.ppi3;
+        ppi3.set_task_endpoint(gpiote.channel1().task_out());
+        ppi3.set_event_endpoint(&board.TIMER0.events_compare[2]);
+        ppi3.enable();
+
+        // The Timer PAC is used directly as the HAL does not give full access to all registers
+        board.TIMER0.mode.write(|w| unsafe { w.bits(0) });
+        board.TIMER0.bitmode.write(|w| unsafe { w.bits(0) });
+        // CC[0] every 20 ms (50 Hz)
+        board.TIMER0.cc[0].write(|w| unsafe { w.bits(20000) });
+        board.TIMER0.shorts.write(|w| unsafe { w.bits(1) });
+        // Servo duty cycle is from 0.5 ms to 2.5 ms with 1.5 ms for center position
+        board.TIMER0.cc[1].write(|w| unsafe { w.bits(1500) });
+        board.TIMER0.cc[2].write(|w| unsafe { w.bits(1500) });
+        board.TIMER0.tasks_start.write(|w| unsafe { w.bits(1) });
+        // Timer0 interrupt on CC[0]
+        board.TIMER0.intenset.write(|w| unsafe { w.bits(1 << 16) });
+
+        cortex_m::interrupt::free(move |cs| {
+            *SERVO_TIMER.borrow(cs).borrow_mut() = Some(board.TIMER0);
+        });
+        unsafe {
+            pac::NVIC::unmask(pac::Interrupt::TIMER0);
+        }
+
+        loop {}
+    }
+    panic!("End");
+}
+
+#[interrupt]
+fn TIMER0() {
+    // Change Servo position at the start of the duty cycle. Then there is no race condition
+    // between changing the duty cycle and a CC event.
+    static mut SPEED: i32 = 1500;
+    static mut DIRECTION: i32 = 1;
+    match SPEED {
+        i32::MIN..=500 => *DIRECTION = 1,
+        2500..=i32::MAX => *DIRECTION = -1,
+        _ => {}
+    }
+    *SPEED += *DIRECTION;
+    cortex_m::interrupt::free(|cs| {
+        //    if let Some(cc_value) = CC_VALUE.borrow(cs).borrow().as_ref() {
+        if let Some(timer) = SERVO_TIMER.borrow(cs).borrow_mut().as_mut() {
+            //timer.cc[1].write(|w|unsafe { w.bits(u32::try_from(*cc_value).unwrap_or(1500)) });
+            let set_speed = u32::try_from(*SPEED).unwrap_or(1500);
+            timer.cc[1].write(|w| unsafe { w.bits(set_speed) });
+            timer.cc[2].write(|w| unsafe { w.bits(set_speed) });
+            timer.events_compare[0].write(|w| unsafe { w.bits(0) });
+        }
+        //}
+    });
+}

--- a/examples/servo/src/main.rs
+++ b/examples/servo/src/main.rs
@@ -25,16 +25,9 @@ fn main() -> ! {
     if let Some(board) = Board::take() {
         let gpiote = Gpiote::new(board.GPIOTE);
         // Servo output pins
-        #[cfg(feature = "v1")]
-        let servopin1 = board.pins.p0_01.into_push_pull_output(Level::Low).degrade(); // PAD3
-        #[cfg(feature = "v1")]
-        let servopin2 = board.pins.p0_02.into_push_pull_output(Level::Low).degrade(); // PAD2
-        
-        #[cfg(feature = "v2")]
-        let servopin1 = board.pins.p0_03.into_push_pull_output(Level::Low).degrade(); // PAD2
-        #[cfg(feature = "v2")]
-        let servopin2 = board.pins.p0_04.into_push_pull_output(Level::Low).degrade(); // PAD3
-        
+        let servopin1 = board.edge.e01.into_push_pull_output(Level::Low).degrade(); // PAD2
+        let servopin2 = board.edge.e02.into_push_pull_output(Level::Low).degrade(); // PAD3
+
         // Output channel for Servo 1
         gpiote
             .channel0()

--- a/examples/v2-microphone/src/main.rs
+++ b/examples/v2-microphone/src/main.rs
@@ -25,7 +25,7 @@ fn main() -> ! {
 
         // initialize adc
         let saadc_config = SaadcConfig::default();
-        let mut saadc = Saadc::new(board.SAADC, saadc_config);
+        let mut saadc = Saadc::new(board.ADC, saadc_config);
         let mut mic_in = board.microphone_pins.mic_in.into_floating_input();
 
         // enable microphone

--- a/microbit-common/src/adc.rs
+++ b/microbit-common/src/adc.rs
@@ -1,0 +1,6 @@
+//! ADC
+#[cfg(feature = "v1")]
+pub use crate::v1::adc::*;
+
+#[cfg(feature = "v2")]
+pub use crate::v2::adc::*;

--- a/microbit-common/src/lib.rs
+++ b/microbit-common/src/lib.rs
@@ -18,6 +18,7 @@ pub use nrf52833_hal as hal;
 pub use hal::pac;
 pub use hal::pac::Peripherals;
 
+pub mod adc;
 pub mod board;
 pub mod display;
 pub mod gpio;

--- a/microbit-common/src/v1/adc.rs
+++ b/microbit-common/src/v1/adc.rs
@@ -1,0 +1,18 @@
+use crate::hal;
+
+/// Adc alias to unify v1 and v2 names
+pub type Adc = hal::Adc;
+/// AdcConfig alias to unify v1 and v2 names
+pub type AdcConfig = hal::adc::AdcConfig;
+
+/// Same resolution for v1 and v2
+pub trait Default {
+    /// v1 is limited to 10 bit
+    fn default_10bit() -> Self;
+}
+
+impl Default for AdcConfig {
+    fn default_10bit() -> Self {
+        AdcConfig::default()
+    }
+}

--- a/microbit-common/src/v1/board.rs
+++ b/microbit-common/src/v1/board.rs
@@ -1,4 +1,7 @@
-use super::gpio::{DisplayPins, BTN_A, BTN_B, SCL, SDA, UART_RX, UART_TX};
+use super::gpio::{
+    DisplayPins, BTN_A, BTN_B, EDGE00, EDGE01, EDGE02, EDGE08, EDGE12, EDGE16, SCL, SDA, UART_RX,
+    UART_TX,
+};
 use crate::{
     hal::{
         gpio::{p0, Disconnected, Level},
@@ -12,6 +15,9 @@ use crate::{
 pub struct Board {
     /// GPIO pins that are not otherwise used
     pub pins: Pins,
+
+    /// Unused GPIO pins on edge connector
+    pub edge: Edge,
 
     /// display pins
     pub display_pins: DisplayPins,
@@ -70,6 +76,9 @@ pub struct Board {
     /// nRF51 peripheral: GPIOTE
     pub GPIOTE: pac::GPIOTE,
 
+    /// nRF51 preipheral: PPI
+    pub PPI: pac::PPI,
+
     /// nRF51 peripheral: RADIO
     pub RADIO: pac::RADIO,
 
@@ -124,19 +133,27 @@ impl Board {
         let p0parts = p0::Parts::new(p.GPIO);
         Self {
             pins: Pins {
-                p0_01: p0parts.p0_01,
-                p0_02: p0parts.p0_02,
-                p0_03: p0parts.p0_03,
-                p0_16: p0parts.p0_16,
-                p0_18: p0parts.p0_18,
+                //p0_01: p0parts.p0_01,
+                //p0_02: p0parts.p0_02,
+                //p0_03: p0parts.p0_03,
+                //p0_16: p0parts.p0_16,
+                //p0_18: p0parts.p0_18,
                 p0_19: p0parts.p0_19,
-                p0_20: p0parts.p0_20,
+                //p0_20: p0parts.p0_20,
                 p0_21: p0parts.p0_21,
                 p0_22: p0parts.p0_22,
                 p0_23: p0parts.p0_23,
                 p0_27: p0parts.p0_27,
                 p0_28: p0parts.p0_28,
                 p0_29: p0parts.p0_29,
+            },
+            edge: Edge {
+                e00: p0parts.p0_03,
+                e01: p0parts.p0_02,
+                e02: p0parts.p0_01,
+                e08: p0parts.p0_18,
+                e12: p0parts.p0_20,
+                e16: p0parts.p0_16,
             },
             display_pins: DisplayPins {
                 row1: p0parts.p0_13.into_push_pull_output(Level::Low),
@@ -183,6 +200,7 @@ impl Board {
             CLOCK: p.CLOCK,
             FICR: p.FICR,
             GPIOTE: p.GPIOTE,
+            PPI: p.PPI,
             RADIO: p.RADIO,
             RNG: p.RNG,
             RTC0: p.RTC0,
@@ -200,9 +218,9 @@ impl Board {
 #[allow(missing_docs)]
 pub struct Pins {
     // pub p0_00: p0::P0_00<Disconnected>, // SCL
-    pub p0_01: p0::P0_01<Disconnected>,
-    pub p0_02: p0::P0_02<Disconnected>,
-    pub p0_03: p0::P0_03<Disconnected>,
+    // pub p0_01: p0::P0_01<Disconnected>, // PAD2, EDGE02
+    // pub p0_02: p0::P0_02<Disconnected>, // PAD1, EDGE01
+    // pub p0_03: p0::P0_03<Disconnected>, // PAD0, EDGE00
     // pub p0_04: p0::P0_04<Disconnected>, // LEDs
     // pub p0_05: p0::P0_05<Disconnected>, // LEDs
     // pub p0_06: p0::P0_06<Disconnected>, // LEDs
@@ -215,11 +233,11 @@ pub struct Pins {
     // pub p0_13: p0::P0_13<Disconnected>, // LEDs
     // pub p0_14: p0::P0_14<Disconnected>, // LEDs
     // pub p0_15: p0::P0_15<Disconnected>, // LEDs
-    pub p0_16: p0::P0_16<Disconnected>,
+    // pub p0_16: p0::P0_16<Disconnected>, // EDGE16
     // pub p0_17: p0::P0_17<Disconnected>, // BTN_A
-    pub p0_18: p0::P0_18<Disconnected>,
+    // pub p0_18: p0::P0_18<Disconnected>, // EDGE08
     pub p0_19: p0::P0_19<Disconnected>,
-    pub p0_20: p0::P0_20<Disconnected>,
+    // pub p0_20: p0::P0_20<Disconnected>, // EDGE12
     pub p0_21: p0::P0_21<Disconnected>,
     pub p0_22: p0::P0_22<Disconnected>,
     pub p0_23: p0::P0_23<Disconnected>,
@@ -230,6 +248,36 @@ pub struct Pins {
     pub p0_28: p0::P0_28<Disconnected>,
     pub p0_29: p0::P0_29<Disconnected>,
     // pub p0_30: p0::P0_30<Disconnected>, // SDA
+}
+
+/// Unused edge connector pins
+#[allow(missing_docs)]
+pub struct Edge {
+    // pub e03: COL1,
+    pub e00: EDGE00<Disconnected>, // <- big pad 1
+    // pub e04: COL2,
+    // pub e05: BTN_A,
+    // pub e06: COL9,
+    // pub e07: COL8,
+    pub e01: EDGE01<Disconnected>, // <- big pad 2
+    pub e08: EDGE08<Disconnected>,
+    // pub e09: COL7,
+    // pub e10: COL3,
+    // pub e11: BTN_B,
+    pub e12: EDGE12<Disconnected>,
+    pub e02: EDGE02<Disconnected>, // <- big pad 3
+    //pub e13<MODE>: SCK<MODE>,
+    //pub e14<MODE>: MISO<MODE>,
+    //pub e15<MODE>: MOSI<MODE>,
+    pub e16: EDGE16<Disconnected>,
+    // +V
+    // +V
+    // +V
+    // pub e19: SCL,
+    // pub e20: SDA,
+    // GND
+    // GND
+    // GND
 }
 
 /// Board buttons

--- a/microbit-common/src/v1/gpio.rs
+++ b/microbit-common/src/v1/gpio.rs
@@ -8,9 +8,9 @@
 use crate::hal::gpio::{p0, Floating, Input, Output, Pin, PushPull};
 
 /* GPIO pads */
-pub type PAD1<MODE> = p0::P0_03<MODE>;
-pub type PAD2<MODE> = p0::P0_02<MODE>;
-pub type PAD3<MODE> = p0::P0_01<MODE>;
+pub type PAD0<MODE> = p0::P0_03<MODE>;
+pub type PAD1<MODE> = p0::P0_02<MODE>;
+pub type PAD2<MODE> = p0::P0_01<MODE>;
 
 /* LED display */
 pub const NUM_COLS: usize = 9;
@@ -136,28 +136,28 @@ pub type UART_TX = p0::P0_24<Output<PushPull>>;
 pub type UART_RX = p0::P0_25<Input<Floating>>;
 
 /* edge connector */
-pub type EDGE01 = COL1;
-pub type EDGE02<MODE> = PAD1<MODE>; // <- big pad 1
-pub type EDGE03 = COL2;
-pub type EDGE04 = BTN_A;
-pub type EDGE05 = COL9;
-pub type EDGE06 = COL8;
-pub type EDGE07<MODE> = PAD2<MODE>; // <- big pad 2
+pub type EDGE03 = COL1;
+pub type EDGE00<MODE> = PAD0<MODE>; // <- big pad 1
+pub type EDGE04 = COL2;
+pub type EDGE05 = BTN_A;
+pub type EDGE06 = COL9;
+pub type EDGE07 = COL8;
+pub type EDGE01<MODE> = PAD1<MODE>; // <- big pad 2
 pub type EDGE08<MODE> = p0::P0_18<MODE>;
 pub type EDGE09 = COL7;
 pub type EDGE10 = COL3;
 pub type EDGE11 = BTN_B;
 pub type EDGE12<MODE> = p0::P0_20<MODE>;
-pub type EDGE13<MODE> = PAD3<MODE>; // <- big pad 3
-pub type EDGE14<MODE> = SCK<MODE>;
-pub type EDGE15<MODE> = MISO<MODE>;
-pub type EDGE16<MODE> = MOSI<MODE>;
-pub type EDGE17<MODE> = p0::P0_16<MODE>;
+pub type EDGE02<MODE> = PAD2<MODE>; // <- big pad 3
+pub type EDGE13<MODE> = SCK<MODE>;
+pub type EDGE14<MODE> = MISO<MODE>;
+pub type EDGE15<MODE> = MOSI<MODE>;
+pub type EDGE16<MODE> = p0::P0_16<MODE>;
 // EDGE18 -> +V
 // EDGE19 -> +V
 // EDGE20 -> +V
-pub type EDGE21 = SCL;
-pub type EDGE22 = SDA;
+pub type EDGE19 = SCL;
+pub type EDGE20 = SDA;
 // EDGE23 -> GND
 // EDGE24 -> GND
 // EDGE25 -> GND

--- a/microbit-common/src/v1/mod.rs
+++ b/microbit-common/src/v1/mod.rs
@@ -1,2 +1,3 @@
+pub mod adc;
 pub mod board;
 pub mod gpio;

--- a/microbit-common/src/v2/adc.rs
+++ b/microbit-common/src/v2/adc.rs
@@ -1,0 +1,20 @@
+use crate::hal;
+
+/// Adc alias to unify v1 and v2 names
+pub type Adc = hal::Saadc;
+/// AdcConfig alias to unify v1 and v2 names
+pub type AdcConfig = hal::saadc::SaadcConfig;
+
+/// Same resolution for v1 and v2
+pub trait Default {
+    /// v1 is limited to 10 bit
+    fn default_10bit() -> Self;
+}
+
+impl Default for AdcConfig {
+    fn default_10bit() -> Self {
+        let mut adcconfig: AdcConfig = AdcConfig::default();
+        adcconfig.resolution = hal::saadc::Resolution::_10BIT;
+        adcconfig
+    }
+}

--- a/microbit-common/src/v2/board.rs
+++ b/microbit-common/src/v2/board.rs
@@ -1,5 +1,6 @@
 use super::gpio::{
-    DisplayPins, MicrophonePins, BTN_A, BTN_B, INT_SCL, INT_SDA, SCL, SDA, UART_RX, UART_TX,
+    DisplayPins, MicrophonePins, BTN_A, BTN_B, EDGE00, EDGE01, EDGE02, EDGE08, EDGE09, EDGE12,
+    EDGE16, INT_SCL, INT_SDA, SCL, SDA, UART_RX, UART_TX,
 };
 use crate::{
     hal::{
@@ -14,6 +15,9 @@ use crate::{
 pub struct Board {
     /// GPIO pins that are not otherwise used
     pub pins: Pins,
+
+    /// Unused GPIO pins on edge connector
+    pub edge: Edge,
 
     /// display pins
     pub display_pins: DisplayPins,
@@ -81,6 +85,9 @@ pub struct Board {
     /// nRF52 peripheral: GPIOTE
     pub GPIOTE: pac::GPIOTE,
 
+    /// nRF52 preipheral: PPI
+    pub PPI: pac::PPI,
+
     /// nRF52 peripheral: PWM0
     pub PWM0: pac::PWM0,
 
@@ -140,7 +147,7 @@ pub struct Board {
     pub UARTE1: pac::UARTE1,
 
     /// nRF52 peripheral: SAADC
-    pub SAADC: pac::SAADC,
+    pub ADC: pac::SAADC,
 }
 
 impl Board {
@@ -170,13 +177,13 @@ impl Board {
         Self {
             pins: Pins {
                 p0_01: p0parts.p0_01,
-                p0_02: p0parts.p0_02,
-                p0_03: p0parts.p0_03,
-                p0_04: p0parts.p0_04,
+                //p0_02: p0parts.p0_02,
+                //p0_03: p0parts.p0_03,
+                //p0_04: p0parts.p0_04,
                 p0_07: p0parts.p0_07,
-                p0_09: p0parts.p0_09,
-                p0_10: p0parts.p0_10,
-                p0_12: p0parts.p0_12,
+                //p0_09: p0parts.p0_09,
+                //p0_10: p0parts.p0_10,
+                //p0_12: p0parts.p0_12,
                 p0_13: p0parts.p0_13,
                 p0_17: p0parts.p0_17,
                 p0_18: p0parts.p0_18,
@@ -184,12 +191,21 @@ impl Board {
                 p0_27: p0parts.p0_27,
                 p0_29: p0parts.p0_29,
                 p1_01: p1parts.p1_01,
-                p1_02: p1parts.p1_02,
+                //p1_02: p1parts.p1_02,
                 p1_03: p1parts.p1_03,
                 p1_04: p1parts.p1_04,
                 p1_06: p1parts.p1_06,
                 p1_07: p1parts.p1_07,
                 p1_09: p1parts.p1_09,
+            },
+            edge: Edge {
+                e00: p0parts.p0_02,
+                e01: p0parts.p0_03,
+                e02: p0parts.p0_04,
+                e08: p0parts.p0_10,
+                e09: p0parts.p0_09,
+                e12: p0parts.p0_12,
+                e16: p1parts.p1_02,
             },
             display_pins: DisplayPins {
                 col1: p0parts.p0_28.into_push_pull_output(Level::High),
@@ -245,6 +261,7 @@ impl Board {
             CLOCK: p.CLOCK,
             FICR: p.FICR,
             GPIOTE: p.GPIOTE,
+            PPI: p.PPI,
             PWM0: p.PWM0,
             PWM1: p.PWM1,
             PWM2: p.PWM2,
@@ -264,7 +281,7 @@ impl Board {
             TWIS0: p.TWIS0,
             UARTE0: p.UARTE0,
             UARTE1: p.UARTE1,
-            SAADC: p.SAADC,
+            ADC: p.SAADC,
         }
     }
 }
@@ -274,17 +291,17 @@ impl Board {
 pub struct Pins {
     // pub p0_00: p0::P0_00<Disconnected>, // Speaker
     pub p0_01: p0::P0_01<Disconnected>,
-    pub p0_02: p0::P0_02<Disconnected>,
-    pub p0_03: p0::P0_03<Disconnected>,
-    pub p0_04: p0::P0_04<Disconnected>,
+    // pub p0_02: p0::P0_02<Disconnected>, // PAD0, EDGE00
+    // pub p0_03: p0::P0_03<Disconnected>, // PAD1, EDGE01
+    // pub p0_04: p0::P0_04<Disconnected>, // PAD2, EDGE02
     // pub p0_05: p0::P0_05<Disconnected>, // Microphone IN
     // pub p0_06: p0::P0_06<Disconnected>, // UART RX
     pub p0_07: p0::P0_07<Disconnected>,
     // pub p0_08: p0::P0_08<Disconnected>, // INT_SCL
-    pub p0_09: p0::P0_09<Disconnected>,
-    pub p0_10: p0::P0_10<Disconnected>,
+    // pub p0_09: p0::P0_09<Disconnected>, // EDGE09
+    // pub p0_10: p0::P0_10<Disconnected>, // EDGE08
     // pub p0_11: p0::P0_11<Disconnected>, // LEDs
-    pub p0_12: p0::P0_12<Disconnected>,
+    // pub p0_12: p0::P0_12<Disconnected>, // EDGE12
     pub p0_13: p0::P0_13<Disconnected>,
     // pub p0_14: p0::P0_14<Disconnected>, // BTN_A
     // pub p0_15: p0::P0_15<Disconnected>, // LEDs
@@ -306,7 +323,7 @@ pub struct Pins {
     // pub p0_31: p0::P0_31<Disconnected>, // LEDs
     // pub p1_00: p1::P1_00<Disconnected>, // SDA
     pub p1_01: p1::P1_01<Disconnected>,
-    pub p1_02: p1::P1_02<Disconnected>,
+    // pub p1_02: p1::P1_02<Disconnected>, // EDGE16
     pub p1_03: p1::P1_03<Disconnected>,
     pub p1_04: p1::P1_04<Disconnected>,
     // pub p1_05: p1::P1_05<Disconnected>, // LEDs
@@ -314,6 +331,37 @@ pub struct Pins {
     pub p1_07: p1::P1_07<Disconnected>,
     // pub p1_08: p1::P1_08<Disconnected>, // UART TX
     pub p1_09: p1::P1_09<Disconnected>,
+}
+
+/// Unused edge connector pins
+#[allow(missing_docs)]
+pub struct Edge {
+    /* edge connector */
+    // pub e03: COL3,
+    pub e00: EDGE00<Disconnected>, // <- big pad 1
+    // pub e04: COL1,
+    // pub e05: BTN_A,
+    // pub e06: COL4,
+    // pub e07: COL2,
+    pub e01: EDGE01<Disconnected>, // <- big pad 2
+    pub e08: EDGE08<Disconnected>,
+    pub e09: EDGE09<Disconnected>,
+    // pub e10: COL5,
+    // pub e11: BTN_B,
+    pub e12: EDGE12<Disconnected>,
+    pub e02: EDGE02<Disconnected>, // <- big pad 3
+    //pub e13<MODE>: SCK<MODE>,
+    //pub e14<MODE>: MISO<MODE>,
+    //pub e15<MODE>: MOSI<MODE>,
+    pub e16: EDGE16<Disconnected>,
+    // +V
+    // +V
+    // +V
+    // pub e19: SCL,
+    // pub e20: SDA,
+    // GND
+    // GND
+    // GND
 }
 
 /// Buttons

--- a/microbit-common/src/v2/gpio.rs
+++ b/microbit-common/src/v2/gpio.rs
@@ -1,6 +1,11 @@
 #![allow(clippy::upper_case_acronyms, missing_docs)]
 use nrf52833_hal::gpio::{p0, p1, Floating, Input, OpenDrain, Output, Pin, PushPull};
 
+/* GPIO pads */
+pub type PAD0<MODE> = p0::P0_02<MODE>;
+pub type PAD1<MODE> = p0::P0_03<MODE>;
+pub type PAD2<MODE> = p0::P0_04<MODE>;
+
 /* LED display */
 pub const NUM_COLS: usize = 5;
 pub type COL1 = p0::P0_28<Output<PushPull>>;
@@ -125,3 +130,30 @@ pub type UART_RX = p1::P1_08<Input<Floating>>;
 
 /* speaker */
 pub type SPEAKER = p0::P0_00<Output<PushPull>>;
+
+/* edge connector */
+pub type EDGE03 = COL3;
+pub type EDGE00<MODE> = PAD0<MODE>; // <- big pad 1
+pub type EDGE04 = COL1;
+pub type EDGE05 = BTN_A;
+pub type EDGE06 = COL4;
+pub type EDGE07 = COL2;
+pub type EDGE01<MODE> = PAD1<MODE>; // <- big pad 2
+pub type EDGE08<MODE> = p0::P0_10<MODE>;
+pub type EDGE09<MODE> = p0::P0_09<MODE>;
+pub type EDGE10 = COL5;
+pub type EDGE11 = BTN_B;
+pub type EDGE12<MODE> = p0::P0_12<MODE>;
+pub type EDGE02<MODE> = PAD2<MODE>; // <- big pad 3
+pub type EDGE13<MODE> = SCK<MODE>;
+pub type EDGE14<MODE> = MISO<MODE>;
+pub type EDGE15<MODE> = MOSI<MODE>;
+pub type EDGE16<MODE> = p1::P1_02<MODE>;
+// EDGE18 -> +V
+// EDGE19 -> +V
+// EDGE20 -> +V
+pub type EDGE19 = SCL;
+pub type EDGE20 = SDA;
+// EDGE23 -> GND
+// EDGE24 -> GND
+// EDGE25 -> GND

--- a/microbit-common/src/v2/mod.rs
+++ b/microbit-common/src/v2/mod.rs
@@ -1,2 +1,3 @@
+pub mod adc;
 pub mod board;
 pub mod gpio;


### PR DESCRIPTION
Hi,
I have added common type aliases and structs for the GPIO pins on the edge connector. I did the same for ADC and SAADC with a common default initialization for 10 bit resolution. It is now possible to use the same code for v1 and v2 if the extra capabilities of v2 are not needed. There is also a new analog example using the common interface and a TIMER, GPIOTE and PPI servo example.

Cheers, Torsten