### PR TITLE
added coordiante system documentation info.

### DIFF
--- a/microbit-common/src/display/blocking.rs
+++ b/microbit-common/src/display/blocking.rs
@@ -35,6 +35,24 @@
 //! }
 //! ```
 //!
+//! The coordiante system is oriented so the 'bottom' (x,4) row is the edge with the edge
+//! connector. That means that
+//!
+//! ```no_run
+//! display.show(
+//!    &mut timer,
+//!    [
+//!        [0, 0, 1, 0, 0],
+//!        [0, 1, 1, 1, 0],
+//!        [1, 0, 1, 0, 1],
+//!        [0, 0, 1, 0, 0],
+//!        [0, 0, 1, 0, 0],
+//!    ],
+//!    1000,
+//!);
+//! ```
+//! Will display an arrow pointing towards the boards usb port.
+//!
 //! For a working example [`examples/display-blocking`](https://github.com/nrf-rs/microbit/tree/main/examples/display-blocking)
 use crate::hal::{
     gpio::{Output, Pin, PushPull},

--- a/microbit-common/src/display/nonblocking/mod.rs
+++ b/microbit-common/src/display/nonblocking/mod.rs
@@ -62,6 +62,8 @@
 //! (0,4) ... (4,4)
 //! ```
 //!
+//! where the 'bottom' (x,4) of the board is the edge connector.
+//!
 //! ## Greyscale model
 //!
 //! LED brightness levels are described using a scale from 0 (off) to 9


### PR DESCRIPTION
In the documentation for Display::blocking, it would be useful to mention the orientation of the display relative to the rest of the board.

fixes #118