### PR TITLE
Fix blocking::Display::set_refresh_rate()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+- Fix the `blocking::Display::set_refresh_rate` calculation for the micro:bit V2
 - Double the non-blocking display refresh frequency for the micro:bit V2
 - Fix faulty doc test in `blocking.rs`
 - Update the non-blocking display documentation to better explain when methods

--- a/microbit-common/src/display/blocking.rs
+++ b/microbit-common/src/display/blocking.rs
@@ -123,7 +123,7 @@ impl Display {
 
     /// Set refresh rate, time for matrix scan
     pub fn set_refresh_rate(&mut self, freq_hz: u32) {
-        self.delay_ms = 1000 / freq_hz / 3;
+        self.delay_ms = 1000 / freq_hz / (NUM_ROWS as u32);
     }
 
     /// Convert 5x5 image to 3x9 matrix


### PR DESCRIPTION
The calculation in `display::blocking::Display::set_refresh_rate` was wrong for the micro:bit v2.

For example, `set_refresh_rate(60)` gave a refresh rate of 36Hz rather than 60Hz.

To see the difference, add

````
  display.set_refresh_rate(60);
````

to `examples/display-blocking/src/main.rs`

