### PR TITLE
Non-blocking display: change the order of GPIO writes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+- Fix: non-blocking display on micro:bit V2 could spuriously light LEDs briefly
 - Fix the `blocking::Display::set_refresh_rate` calculation for the micro:bit V2
 - Double the non-blocking display refresh frequency for the micro:bit V2
 - Fix faulty doc test in `blocking.rs`


### PR DESCRIPTION
Closes #108

On the micro:bit v2 the GPIO pins are on two ports, and it takes four IO writes to update all the pins: one "clear multiple pins" and one "set multiple pins" per port.

(It's possible to set pins to both low and high using `OUT`, but we can't use that as we don't own all the pins on the port.)

So there is a brief period where the pins are in a mix of the old and new states, and evidently in debug builds this can persist for long enough to be visible.

We can fix this by changing the order of writes: make the first write be the one that makes the old row dark, and the last one be the one that makes the new row light.

We might as well also arrange the code so that it doesn't perform any calculations between the GPIO writes (on the theory that in debug mode the compiler probably won't be reordering things).

With those changes I no longer see spurious lighting in the example image from #108.
