### PR TITLE
WIP: port of microbit to embassy

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -4,27 +4,14 @@ xtask = "run --package xtask --"
 # For micro:bit v1.x
 
 [target.thumbv6m-none-eabi]
-runner = 'probe-run --chip nRF51822_xxAA'
-rustflags = [
-  "-C", "linker=flip-link",
-  "-C", "link-arg=-Tlink.x",
-  "-C", "link-arg=-Tdefmt.x",
-]
+runner = 'probe-rs run --chip nRF51822_xxAA'
 
 # For micro:bit v2
-
 [target.thumbv7em-none-eabi]
-runner = "probe-run --chip nRF52833_xxAA"
-rustflags = [
-  "-C", "linker=flip-link",
-  "-C", "link-arg=-Tlink.x",
-  "-C", "link-arg=-Tdefmt.x",
-]
+runner = "probe-rs run --chip nRF52833_xxAA"
 
 [target.thumbv7em-none-eabihf]
-runner = "probe-run --chip nRF52833_xxAA"
-rustflags = [
-  "-C", "linker=flip-link",
-  "-C", "link-arg=-Tlink.x",
-  "-C", "link-arg=-Tdefmt.x",
-]
+runner = "probe-rs run --chip nRF52833_xxAA"
+
+[env]
+DEFMT_LOG = "trace"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,3 +6,11 @@ members = [
   "examples/*",
   "xtask",
 ]
+resolver = "2"
+
+[profile.release]
+debug = 2
+
+[patch.crates-io]
+embassy-nrf = { path = "../embassy/embassy-nrf" }
+embassy-time = { path = "../embassy/embassy-time" }

--- a/build.rs
+++ b/build.rs
@@ -15,4 +15,7 @@ fn main() {
     // Only re-run the build script when memory.x is changed,
     // instead of when any part of the source code changes.
     println!("cargo:rerun-if-changed=memory.x");
+    println!("cargo:rustc-link-arg-bins=--nmagic");
+    println!("cargo:rustc-link-arg-bins=-Tlink.x");
+    println!("cargo:rustc-link-arg-bins=-Tdefmt.x");
 }

--- a/examples/analog/Cargo.toml
+++ b/examples/analog/Cargo.toml
@@ -9,8 +9,8 @@ edition = "2018"
 cortex-m = { version = "0.7.3", features = ["critical-section-single-core"]}
 cortex-m-rt = "0.7"
 panic-halt = "0.2.0"
-defmt-rtt = "0.3.2"
-defmt = "0.3.1"
+defmt-rtt = "0.4"
+defmt = "0.3"
 
 [dependencies.microbit]
 path = "../../microbit"
@@ -23,15 +23,3 @@ optional = true
 [features]
 v1 = ["microbit"]
 v2 = ["microbit-v2"]
-
-default = [
-  "defmt-default",
-]
-
-# do NOT modify these features
-defmt-default = []
-defmt-trace = []
-defmt-debug = []
-defmt-info = []
-defmt-warn = []
-defmt-error = []

--- a/examples/display-blocking/Cargo.toml
+++ b/examples/display-blocking/Cargo.toml
@@ -6,9 +6,11 @@ edition = "2018"
 [dependencies]
 cortex-m = { version = "0.7", features = ["critical-section-single-core"]}
 cortex-m-rt = "0.7"
-panic-halt = "0.2.0"
+panic-probe = { version = "0.3.1", features = ["print-defmt"] }
 defmt-rtt = "0.4"
-defmt = "0.3.1"
+defmt = "0.3"
+
+embedded-hal = "1.0"
 
 [dependencies.microbit]
 path = "../../microbit"
@@ -21,15 +23,3 @@ optional = true
 [features]
 v1 = ["microbit"]
 v2 = ["microbit-v2"]
-
-default = [
-  "defmt-default",
-]
-
-# do NOT modify these features
-defmt-default = []
-defmt-trace = []
-defmt-debug = []
-defmt-info = []
-defmt-warn = []
-defmt-error = []

--- a/examples/display-blocking/src/main.rs
+++ b/examples/display-blocking/src/main.rs
@@ -2,85 +2,79 @@
 #![no_main]
 
 use defmt_rtt as _;
-use panic_halt as _;
+use panic_probe as _;
 
 use cortex_m_rt::entry;
 
-use microbit::{
-    board::Board,
-    display::blocking::Display,
-    hal::{prelude::*, Timer},
-};
+use embedded_hal::delay::DelayNs;
+use microbit::{board::Board, display::blocking::Display, time::Delay};
 
 #[entry]
 fn main() -> ! {
-    if let Some(board) = Board::take() {
-        let mut timer = Timer::new(board.TIMER0);
-        let mut display = Display::new(board.display_pins);
+    let board = Board::default();
+    let mut display = Display::new(board.display_pins);
 
-        #[allow(non_snake_case)]
-        let letter_I = [
-            [0, 1, 1, 1, 0],
-            [0, 0, 1, 0, 0],
-            [0, 0, 1, 0, 0],
-            [0, 0, 1, 0, 0],
-            [0, 1, 1, 1, 0],
-        ];
+    #[allow(non_snake_case)]
+    let letter_I = [
+        [0, 1, 1, 1, 0],
+        [0, 0, 1, 0, 0],
+        [0, 0, 1, 0, 0],
+        [0, 0, 1, 0, 0],
+        [0, 1, 1, 1, 0],
+    ];
 
-        let heart = [
-            [0, 1, 0, 1, 0],
-            [1, 0, 1, 0, 1],
-            [1, 0, 0, 0, 1],
-            [0, 1, 0, 1, 0],
-            [0, 0, 1, 0, 0],
-        ];
+    let heart = [
+        [0, 1, 0, 1, 0],
+        [1, 0, 1, 0, 1],
+        [1, 0, 0, 0, 1],
+        [0, 1, 0, 1, 0],
+        [0, 0, 1, 0, 0],
+    ];
 
-        #[allow(non_snake_case)]
-        let letter_R = [
-            [0, 1, 1, 0, 0],
-            [0, 1, 0, 1, 0],
-            [0, 1, 1, 0, 0],
-            [0, 1, 0, 1, 0],
-            [0, 1, 0, 1, 0],
-        ];
+    #[allow(non_snake_case)]
+    let letter_R = [
+        [0, 1, 1, 0, 0],
+        [0, 1, 0, 1, 0],
+        [0, 1, 1, 0, 0],
+        [0, 1, 0, 1, 0],
+        [0, 1, 0, 1, 0],
+    ];
 
-        #[allow(non_snake_case)]
-        let letter_u = [
-            [0, 0, 0, 0, 0],
-            [0, 0, 0, 0, 0],
-            [0, 1, 0, 1, 0],
-            [0, 1, 0, 1, 0],
-            [0, 1, 1, 1, 0],
-        ];
+    #[allow(non_snake_case)]
+    let letter_u = [
+        [0, 0, 0, 0, 0],
+        [0, 0, 0, 0, 0],
+        [0, 1, 0, 1, 0],
+        [0, 1, 0, 1, 0],
+        [0, 1, 1, 1, 0],
+    ];
 
-        #[allow(non_snake_case)]
-        let letter_s = [
-            [0, 0, 0, 0, 0],
-            [0, 0, 1, 1, 0],
-            [0, 1, 0, 0, 0],
-            [0, 0, 1, 0, 0],
-            [0, 1, 1, 1, 0],
-        ];
+    #[allow(non_snake_case)]
+    let letter_s = [
+        [0, 0, 0, 0, 0],
+        [0, 0, 1, 1, 0],
+        [0, 1, 0, 0, 0],
+        [0, 0, 1, 0, 0],
+        [0, 1, 1, 1, 0],
+    ];
 
-        #[allow(non_snake_case)]
-        let letter_t = [
-            [0, 0, 1, 0, 0],
-            [0, 1, 1, 1, 0],
-            [0, 0, 1, 0, 0],
-            [0, 0, 1, 0, 0],
-            [0, 0, 1, 0, 0],
-        ];
-        loop {
-            display.show(&mut timer, letter_I, 1000);
-            display.show(&mut timer, heart, 1000);
-            display.show(&mut timer, letter_R, 1000);
-            display.show(&mut timer, letter_u, 1000);
-            display.show(&mut timer, letter_s, 1000);
-            display.show(&mut timer, letter_t, 1000);
-            display.clear();
-            timer.delay_ms(250_u32);
-        }
+    #[allow(non_snake_case)]
+    let letter_t = [
+        [0, 0, 1, 0, 0],
+        [0, 1, 1, 1, 0],
+        [0, 0, 1, 0, 0],
+        [0, 0, 1, 0, 0],
+        [0, 0, 1, 0, 0],
+    ];
+    let mut timer = Delay;
+    loop {
+        display.show(&mut timer, letter_I, 1000);
+        display.show(&mut timer, heart, 1000);
+        display.show(&mut timer, letter_R, 1000);
+        display.show(&mut timer, letter_u, 1000);
+        display.show(&mut timer, letter_s, 1000);
+        display.show(&mut timer, letter_t, 1000);
+        display.clear();
+        timer.delay_ms(250_u32);
     }
-
-    panic!("End");
 }

--- a/examples/display-nonblocking/Cargo.toml
+++ b/examples/display-nonblocking/Cargo.toml
@@ -8,7 +8,7 @@ cortex-m = { version = "0.7", features = ["critical-section-single-core"]}
 cortex-m-rt = "0.7"
 panic-halt = "0.2.0"
 defmt-rtt = "0.4"
-defmt = "0.3.1"
+defmt = "0.3"
 
 [dependencies.microbit]
 path = "../../microbit"
@@ -21,15 +21,3 @@ optional = true
 [features]
 v1 = ["microbit"]
 v2 = ["microbit-v2"]
-
-default = [
-  "defmt-default",
-]
-
-# do NOT modify these features
-defmt-default = []
-defmt-trace = []
-defmt-debug = []
-defmt-info = []
-defmt-warn = []
-defmt-error = []

--- a/examples/gpio-direct-blinky/Cargo.toml
+++ b/examples/gpio-direct-blinky/Cargo.toml
@@ -20,15 +20,3 @@ optional = true
 [features]
 v1 = ["microbit"]
 v2 = ["microbit-v2"]
-
-default = [
-  "defmt-default",
-]
-
-# do NOT modify these features
-defmt-default = []
-defmt-trace = []
-defmt-debug = []
-defmt-info = []
-defmt-warn = []
-defmt-error = []

--- a/examples/gpio-direct-blinky/src/main.rs
+++ b/examples/gpio-direct-blinky/src/main.rs
@@ -2,6 +2,7 @@
 #![no_std]
 
 use panic_halt as _;
+use defmt_rtt as _;
 
 use cortex_m_rt::entry;
 

--- a/microbit-common/Cargo.toml
+++ b/microbit-common/Cargo.toml
@@ -26,17 +26,12 @@ license = "0BSD"
 
 [dependencies]
 tiny-led-matrix = "1.0.1"
-embedded-hal = "0.2.4"
-
-[dependencies.nrf51-hal]
-optional = true
-version = "0.14.0"
-
-[dependencies.nrf52833-hal]
-optional = true
-version = "0.14.0"
+embedded-hal = "1.0"
+embassy-nrf = { version = "0.1.0", features = ["gpiote", "time-driver-rtc1", "reset-pin-as-gpio", "nfc-pins-as-gpio", "time", "defmt", "unstable-pac", "rt"]}
+embassy-time = { version = "0.3", default-features = false }
+embassy-sync = { version = "0.5", default-features = false }
 
 [features]
 doc = []
-v1 = ["nrf51-hal"]
-v2 = ["nrf52833-hal"]
+v1 = [] # "embassy-nrf/nrf51"]
+v2 = ["embassy-nrf/nrf52833"]

--- a/microbit-common/src/display/nonblocking/control.rs
+++ b/microbit-common/src/display/nonblocking/control.rs
@@ -8,7 +8,7 @@ use tiny_led_matrix::DisplayControl;
 
 use crate::{
     gpio::{NUM_COLS, NUM_ROWS},
-    pac,
+    hal::pac,
 };
 
 const fn pin_bits(pins: &[usize]) -> u32 {

--- a/microbit-common/src/lib.rs
+++ b/microbit-common/src/lib.rs
@@ -9,19 +9,13 @@
 #[cfg(all(feature = "v1", feature = "v2"))]
 compile_error!("canot build for microbit v1 and v2 at the same time");
 
-#[cfg(feature = "v1")]
-pub use nrf51_hal as hal;
-
-#[cfg(feature = "v2")]
-pub use nrf52833_hal as hal;
-
-pub use hal::pac;
-pub use hal::pac::Peripherals;
-
 pub mod adc;
 pub mod board;
 pub mod display;
 pub mod gpio;
+
+pub use embassy_nrf as hal;
+pub use embassy_time as time;
 
 pub use board::Board;
 

--- a/microbit-common/src/v2/adc.rs
+++ b/microbit-common/src/v2/adc.rs
@@ -1,21 +1,6 @@
-use crate::hal;
+use embassy_nrf::saadc;
 
 /// Adc alias to unify v1 and v2 names
-pub type Adc = hal::Saadc;
+pub type Adc = saadc::Saadc<'static, 1>;
 /// AdcConfig alias to unify v1 and v2 names
-pub type AdcConfig = hal::saadc::SaadcConfig;
-
-/// Same resolution for v1 and v2
-pub trait Default {
-    /// v1 is limited to 10 bit
-    fn default_10bit() -> Self;
-}
-
-impl Default for AdcConfig {
-    fn default_10bit() -> Self {
-        AdcConfig {
-            resolution: hal::saadc::Resolution::_10BIT,
-            ..AdcConfig::default()
-        }
-    }
-}
+pub type AdcConfig = saadc::Config;

--- a/microbit-common/src/v2/board.rs
+++ b/microbit-common/src/v2/board.rs
@@ -1,17 +1,24 @@
 use super::gpio::{
-    DisplayPins, MicrophonePins, BTN_A, BTN_B, EDGE00, EDGE01, EDGE02, EDGE08, EDGE09, EDGE12,
-    EDGE16, INT_SCL, INT_SDA, SCL, SDA, UART_RX, UART_TX,
+    DisplayPins, MicrophonePins, EDGE00, EDGE01, EDGE02, EDGE08, EDGE09, EDGE12, EDGE16, INT_SCL,
+    INT_SDA, SCL, SDA, UART_RX, UART_TX,
 };
-use crate::{
-    hal::{
-        gpio::{p0, p1, Disconnected, Level, OpenDrainConfig::Disconnect0HighDrive1},
-        twim, twis, uarte,
+use embassy_nrf::{
+    bind_interrupts,
+    gpio::{Input, Pull},
+    peripherals::{
+        self, GPIOTE_CH0, GPIOTE_CH1, GPIOTE_CH2, GPIOTE_CH3, GPIOTE_CH4, GPIOTE_CH5, GPIOTE_CH6,
+        GPIOTE_CH7, P0_00, P0_01, P0_07, P0_13, P0_17, P0_18, P0_25, P0_27, P0_29, P1_01, P1_03,
+        P1_04, P1_06, P1_07, P1_09, PPI_CH0, PPI_CH1, PPI_CH10, PPI_CH11, PPI_CH12, PPI_CH13,
+        PPI_CH14, PPI_CH15, PPI_CH16, PPI_CH17, PPI_CH18, PPI_CH19, PPI_CH2, PPI_CH3, PPI_CH4,
+        PPI_CH5, PPI_CH6, PPI_CH7, PPI_CH8, PPI_CH9, PWM0, PWM1, PWM2, PWM3, RNG, RTC0, RTC1, RTC2,
+        SAADC, TEMP, TIMER0, TIMER1, TIMER2, TIMER3, TIMER4, TWISPI0, TWISPI1, UARTE0, UARTE1,
     },
-    pac,
+    twim, uarte,
 };
 
 /// Provides access to the microbit
 #[allow(non_snake_case)]
+#[allow(missing_docs)]
 pub struct Board {
     /// GPIO pins that are not otherwise used
     pub pins: Pins,
@@ -26,7 +33,7 @@ pub struct Board {
     pub buttons: Buttons,
 
     /// speaker
-    pub speaker_pin: p0::P0_00<Disconnected>,
+    pub speaker_pin: P0_00,
 
     /// microphone pins
     pub microphone_pins: MicrophonePins,
@@ -40,233 +47,210 @@ pub struct Board {
     /// UART to debugger pins
     pub uart: UartPins,
 
-    /// Core peripheral: Cache and branch predictor maintenance operations
-    pub CBP: pac::CBP,
-
-    /// Core peripheral: CPUID
-    pub CPUID: pac::CPUID,
-
-    /// Core peripheral: Debug Control Block
-    pub DCB: pac::DCB,
-
-    /// Core peripheral: Data Watchpoint and Trace unit
-    pub DWT: pac::DWT,
-
-    /// Core peripheral: Flash Patch and Breakpoint unit
-    pub FPB: pac::FPB,
-
-    /// Core peripheral: Floating Point Unit
-    pub FPU: pac::FPU,
-
-    /// Core peripheral: Instrumentation Trace Macrocell
-    pub ITM: pac::ITM,
-
-    /// Core peripheral: Memory Protection Unit
-    pub MPU: pac::MPU,
-
-    /// Core peripheral: Nested Vector Interrupt Controller
-    pub NVIC: pac::NVIC,
-
-    /// Core peripheral: System Control Block
-    pub SCB: pac::SCB,
-
-    /// Core peripheral: SysTick Timer
-    pub SYST: pac::SYST,
-
-    /// Core peripheral: Trace Port Interface Unit
-    pub TPIU: pac::TPIU,
-
-    /// nRF52 peripheral: CLOCK
-    pub CLOCK: pac::CLOCK,
-
-    /// nRF52 peripheral: FICR
-    pub FICR: pac::FICR,
-
     /// nRF52 peripheral: GPIOTE
-    pub GPIOTE: pac::GPIOTE,
+    pub GPIOTE_CH0: GPIOTE_CH0,
+    pub GPIOTE_CH1: GPIOTE_CH1,
+    pub GPIOTE_CH2: GPIOTE_CH2,
+    pub GPIOTE_CH3: GPIOTE_CH3,
+    pub GPIOTE_CH4: GPIOTE_CH4,
+    pub GPIOTE_CH5: GPIOTE_CH5,
+    pub GPIOTE_CH6: GPIOTE_CH6,
+    pub GPIOTE_CH7: GPIOTE_CH7,
 
     /// nRF52 preipheral: PPI
-    pub PPI: pac::PPI,
+    pub PPI_CH0: PPI_CH0,
+    pub PPI_CH1: PPI_CH1,
+    pub PPI_CH2: PPI_CH2,
+    pub PPI_CH3: PPI_CH3,
+    pub PPI_CH4: PPI_CH4,
+    pub PPI_CH5: PPI_CH5,
+    pub PPI_CH6: PPI_CH6,
+    pub PPI_CH7: PPI_CH7,
+    pub PPI_CH8: PPI_CH8,
+    pub PPI_CH9: PPI_CH9,
+    pub PPI_CH10: PPI_CH10,
+    pub PPI_CH11: PPI_CH11,
+    pub PPI_CH12: PPI_CH12,
+    pub PPI_CH13: PPI_CH13,
+    pub PPI_CH14: PPI_CH14,
+    pub PPI_CH15: PPI_CH15,
+    pub PPI_CH16: PPI_CH16,
+    pub PPI_CH17: PPI_CH17,
+    pub PPI_CH18: PPI_CH18,
+    pub PPI_CH19: PPI_CH19,
 
     /// nRF52 peripheral: PWM0
-    pub PWM0: pac::PWM0,
+    pub PWM0: PWM0,
 
     /// nRF52 peripheral: PWM1
-    pub PWM1: pac::PWM1,
+    pub PWM1: PWM1,
 
     /// nRF52 peripheral: PWM2
-    pub PWM2: pac::PWM2,
+    pub PWM2: PWM2,
 
     /// nRF52 peripheral: PWM3
-    pub PWM3: pac::PWM3,
-
-    /// nRF52 peripheral: RADIO
-    pub RADIO: pac::RADIO,
+    pub PWM3: PWM3,
 
     /// nRF52 peripheral: RNG
-    pub RNG: pac::RNG,
+    pub RNG: RNG,
 
     /// nRF52 peripheral: RTC0
-    pub RTC0: pac::RTC0,
+    pub RTC0: RTC0,
 
     /// nRF52 peripheral: RTC1
-    pub RTC1: pac::RTC1,
+    pub RTC1: RTC1,
 
     /// nRF52 peripheral: RTC2
-    pub RTC2: pac::RTC2,
+    pub RTC2: RTC2,
 
     /// nRF52 peripheral: TEMP <br>
     /// Can be used with [`Temp::new()`](`crate::hal::temp::Temp::new()`)
-    pub TEMP: pac::TEMP,
+    pub TEMP: TEMP,
 
     /// nRF52 peripheral: TIMER0
-    pub TIMER0: pac::TIMER0,
+    pub TIMER0: TIMER0,
 
     /// nRF52 peripheral: TIMER1
-    pub TIMER1: pac::TIMER1,
+    pub TIMER1: TIMER1,
 
     /// nRF52 peripheral: TIMER2
-    pub TIMER2: pac::TIMER2,
+    pub TIMER2: TIMER2,
 
     /// nRF52 peripheral: TIMER3
-    pub TIMER3: pac::TIMER3,
+    pub TIMER3: TIMER3,
 
     /// nRF52 peripheral: TIMER4
-    pub TIMER4: pac::TIMER4,
+    pub TIMER4: TIMER4,
 
-    /// nRF52 peripheral: TWIM0
-    pub TWIM0: pac::TWIM0,
+    /// nRF52 peripheral: TWISPI0
+    pub TWISPI0: TWISPI0,
 
-    /// nRF52 peripheral: TWIS0
-    pub TWIS0: pac::TWIS0,
+    /// nRF52 peripheral: TWISPI1
+    pub TWISPI1: TWISPI1,
 
     /// nRF52 peripheral: UARTE0
-    pub UARTE0: pac::UARTE0,
+    pub UARTE0: UARTE0,
 
     /// nRF52 peripheral: UARTE1
-    pub UARTE1: pac::UARTE1,
+    pub UARTE1: UARTE1,
 
     /// nRF52 peripheral: SAADC
-    pub ADC: pac::SAADC,
+    pub ADC: SAADC,
+}
+
+impl Default for Board {
+    fn default() -> Board {
+        Board::new(Default::default())
+    }
 }
 
 impl Board {
     /// Take the peripherals safely
     ///
     /// This method will return an instance of the board the first time it is
-    /// called. It will return only `None` on subsequent calls.
-    /// This function can also return `None` if one of the the peripherals was
-    /// already taken.
-    pub fn take() -> Option<Self> {
-        Some(Self::new(
-            pac::Peripherals::take()?,
-            pac::CorePeripherals::take()?,
-        ))
-    }
-
-    /// Fallback method in the case peripherals and core peripherals were taken
-    /// elsewhere already.
-    ///
-    /// This method will take the peripherals and core peripherals and
-    /// return an instance of the board.
-    ///
-    /// An exemplary usecase is shown in the rtic display example.
-    pub fn new(p: pac::Peripherals, cp: pac::CorePeripherals) -> Self {
-        let p0parts = p0::Parts::new(p.P0);
-        let p1parts = p1::Parts::new(p.P1);
+    /// called. It will panic on subsequent calls.
+    pub fn new(config: embassy_nrf::config::Config) -> Self {
+        let p = embassy_nrf::init(config);
         Self {
             pins: Pins {
-                p0_01: p0parts.p0_01,
+                p0_01: p.P0_01,
                 //p0_02: p0parts.p0_02,
                 //p0_03: p0parts.p0_03,
                 //p0_04: p0parts.p0_04,
-                p0_07: p0parts.p0_07,
+                p0_07: p.P0_07,
                 //p0_09: p0parts.p0_09,
                 //p0_10: p0parts.p0_10,
                 //p0_12: p0parts.p0_12,
-                p0_13: p0parts.p0_13,
-                p0_17: p0parts.p0_17,
-                p0_18: p0parts.p0_18,
-                p0_25: p0parts.p0_25,
-                p0_27: p0parts.p0_27,
-                p0_29: p0parts.p0_29,
-                p1_01: p1parts.p1_01,
-                //p1_02: p1parts.p1_02,
-                p1_03: p1parts.p1_03,
-                p1_04: p1parts.p1_04,
-                p1_06: p1parts.p1_06,
-                p1_07: p1parts.p1_07,
-                p1_09: p1parts.p1_09,
+                p0_13: p.P0_13,
+                p0_17: p.P0_17,
+                p0_18: p.P0_18,
+                p0_25: p.P0_25,
+                p0_27: p.P0_27,
+                p0_29: p.P0_29,
+                p1_01: p.P1_01,
+                //p1_02: p.P1_02,
+                p1_03: p.P1_03,
+                p1_04: p.P1_04,
+                p1_06: p.P1_06,
+                p1_07: p.P1_07,
+                p1_09: p.P1_09,
             },
             edge: Edge {
-                e00: p0parts.p0_02,
-                e01: p0parts.p0_03,
-                e02: p0parts.p0_04,
-                e08: p0parts.p0_10,
-                e09: p0parts.p0_09,
-                e12: p0parts.p0_12,
-                e16: p1parts.p1_02,
+                e00: p.P0_02,
+                e01: p.P0_03,
+                e02: p.P0_04,
+                e08: p.P0_10,
+                e09: p.P0_09,
+                e12: p.P0_12,
+                e16: p.P1_02,
             },
             display_pins: DisplayPins {
-                col1: p0parts.p0_28.into_push_pull_output(Level::High),
-                col2: p0parts.p0_11.into_push_pull_output(Level::High),
-                col3: p0parts.p0_31.into_push_pull_output(Level::High),
-                col4: p1parts.p1_05.into_push_pull_output(Level::High),
-                col5: p0parts.p0_30.into_push_pull_output(Level::High),
-                row1: p0parts.p0_21.into_push_pull_output(Level::Low),
-                row2: p0parts.p0_22.into_push_pull_output(Level::Low),
-                row3: p0parts.p0_15.into_push_pull_output(Level::Low),
-                row4: p0parts.p0_24.into_push_pull_output(Level::Low),
-                row5: p0parts.p0_19.into_push_pull_output(Level::Low),
+                col1: p.P0_28,
+                col2: p.P0_11,
+                col3: p.P0_31,
+                col4: p.P1_05,
+                col5: p.P0_30,
+                row1: p.P0_21,
+                row2: p.P0_22,
+                row3: p.P0_15,
+                row4: p.P0_24,
+                row5: p.P0_19,
             },
             buttons: Buttons {
-                button_a: p0parts.p0_14.into_floating_input(),
-                button_b: p0parts.p0_23.into_floating_input(),
+                button_a: Input::new(p.P0_14, Pull::None),
+                button_b: Input::new(p.P0_23, Pull::None),
             },
-            speaker_pin: p0parts.p0_00,
+            speaker_pin: p.P0_00,
             microphone_pins: MicrophonePins {
-                mic_in: p0parts.p0_05.into_floating_input(),
-                mic_run: p0parts
-                    .p0_20
-                    .into_open_drain_output(Disconnect0HighDrive1, Level::Low),
+                mic_in: p.P0_05,
+                mic_run: p.P0_20,
             },
             i2c_internal: I2CInternalPins {
-                scl: p0parts.p0_08.into_floating_input(),
-                sda: p0parts.p0_16.into_floating_input(),
+                scl: p.P0_08,
+                sda: p.P0_16,
             },
             i2c_external: I2CExternalPins {
-                scl: p0parts.p0_26.into_floating_input(),
-                sda: p1parts.p1_00.into_floating_input(),
+                scl: p.P0_26,
+                sda: p.P1_00,
             },
             uart: UartPins {
-                tx: p0parts.p0_06.into_push_pull_output(Level::High),
-                rx: p1parts.p1_08.into_floating_input(),
+                tx: p.P0_06,
+                rx: p.P1_08,
             },
 
-            // Core peripherals
-            CBP: cp.CBP,
-            CPUID: cp.CPUID,
-            DCB: cp.DCB,
-            DWT: cp.DWT,
-            FPB: cp.FPB,
-            FPU: cp.FPU,
-            ITM: cp.ITM,
-            MPU: cp.MPU,
-            NVIC: cp.NVIC,
-            SCB: cp.SCB,
-            SYST: cp.SYST,
-            TPIU: cp.TPIU,
-
             // nRF52 peripherals
-            CLOCK: p.CLOCK,
-            FICR: p.FICR,
-            GPIOTE: p.GPIOTE,
-            PPI: p.PPI,
+            GPIOTE_CH0: p.GPIOTE_CH0,
+            GPIOTE_CH1: p.GPIOTE_CH1,
+            GPIOTE_CH2: p.GPIOTE_CH2,
+            GPIOTE_CH3: p.GPIOTE_CH3,
+            GPIOTE_CH4: p.GPIOTE_CH4,
+            GPIOTE_CH5: p.GPIOTE_CH5,
+            GPIOTE_CH6: p.GPIOTE_CH6,
+            GPIOTE_CH7: p.GPIOTE_CH7,
+            PPI_CH0: p.PPI_CH0,
+            PPI_CH1: p.PPI_CH1,
+            PPI_CH2: p.PPI_CH2,
+            PPI_CH3: p.PPI_CH3,
+            PPI_CH4: p.PPI_CH4,
+            PPI_CH5: p.PPI_CH5,
+            PPI_CH6: p.PPI_CH6,
+            PPI_CH7: p.PPI_CH7,
+            PPI_CH8: p.PPI_CH8,
+            PPI_CH9: p.PPI_CH9,
+            PPI_CH10: p.PPI_CH10,
+            PPI_CH11: p.PPI_CH11,
+            PPI_CH12: p.PPI_CH12,
+            PPI_CH13: p.PPI_CH13,
+            PPI_CH14: p.PPI_CH14,
+            PPI_CH15: p.PPI_CH15,
+            PPI_CH16: p.PPI_CH16,
+            PPI_CH17: p.PPI_CH17,
+            PPI_CH18: p.PPI_CH18,
+            PPI_CH19: p.PPI_CH19,
             PWM0: p.PWM0,
             PWM1: p.PWM1,
             PWM2: p.PWM2,
             PWM3: p.PWM3,
-            RADIO: p.RADIO,
             RNG: p.RNG,
             RTC0: p.RTC0,
             RTC1: p.RTC1,
@@ -277,8 +261,8 @@ impl Board {
             TIMER2: p.TIMER2,
             TIMER3: p.TIMER3,
             TIMER4: p.TIMER4,
-            TWIM0: p.TWIM0,
-            TWIS0: p.TWIS0,
+            TWISPI0: p.TWISPI0,
+            TWISPI1: p.TWISPI1,
             UARTE0: p.UARTE0,
             UARTE1: p.UARTE1,
             ADC: p.SAADC,
@@ -290,47 +274,47 @@ impl Board {
 #[allow(missing_docs)]
 pub struct Pins {
     // pub p0_00: p0::P0_00<Disconnected>, // Speaker
-    pub p0_01: p0::P0_01<Disconnected>,
+    pub p0_01: P0_01,
     // pub p0_02: p0::P0_02<Disconnected>, // PAD0, EDGE00
     // pub p0_03: p0::P0_03<Disconnected>, // PAD1, EDGE01
     // pub p0_04: p0::P0_04<Disconnected>, // PAD2, EDGE02
     // pub p0_05: p0::P0_05<Disconnected>, // Microphone IN
     // pub p0_06: p0::P0_06<Disconnected>, // UART RX
-    pub p0_07: p0::P0_07<Disconnected>,
+    pub p0_07: P0_07,
     // pub p0_08: p0::P0_08<Disconnected>, // INT_SCL
     // pub p0_09: p0::P0_09<Disconnected>, // EDGE09
     // pub p0_10: p0::P0_10<Disconnected>, // EDGE08
     // pub p0_11: p0::P0_11<Disconnected>, // LEDs
     // pub p0_12: p0::P0_12<Disconnected>, // EDGE12
-    pub p0_13: p0::P0_13<Disconnected>,
+    pub p0_13: P0_13,
     // pub p0_14: p0::P0_14<Disconnected>, // BTN_A
     // pub p0_15: p0::P0_15<Disconnected>, // LEDs
     // pub p0_16: p0::P0_16<Disconnected>, // INT_SDA
-    pub p0_17: p0::P0_17<Disconnected>,
-    pub p0_18: p0::P0_18<Disconnected>,
+    pub p0_17: P0_17,
+    pub p0_18: P0_18,
     // pub p0_19: p0::P0_19<Disconnected>, // LEDs
     // pub p0_20: p0::P0_20<Disconnected>, // Microphone RUN
     // pub p0_21: p0::P0_21<Disconnected>, // LEDs
     // pub p0_22: p0::P0_22<Disconnected>, // LEDs
     // pub p0_23: p0::P0_23<Disconnected>, // BTN_B
     // pub p0_24: p0::P0_24<Disconnected>, // LEDs
-    pub p0_25: p0::P0_25<Disconnected>,
+    pub p0_25: P0_25,
     // pub p0_26: p0::P0_26<Disconnected>, // SCL
-    pub p0_27: p0::P0_27<Disconnected>,
+    pub p0_27: P0_27,
     // pub p0_28: p0::P0_28<Disconnected>, // LEDs
-    pub p0_29: p0::P0_29<Disconnected>,
+    pub p0_29: P0_29,
     // pub p0_30: p0::P0_30<Disconnected>, // LEDs
     // pub p0_31: p0::P0_31<Disconnected>, // LEDs
     // pub p1_00: p1::P1_00<Disconnected>, // SDA
-    pub p1_01: p1::P1_01<Disconnected>,
+    pub p1_01: P1_01,
     // pub p1_02: p1::P1_02<Disconnected>, // EDGE16
-    pub p1_03: p1::P1_03<Disconnected>,
-    pub p1_04: p1::P1_04<Disconnected>,
+    pub p1_03: P1_03,
+    pub p1_04: P1_04,
     // pub p1_05: p1::P1_05<Disconnected>, // LEDs
-    pub p1_06: p1::P1_06<Disconnected>,
-    pub p1_07: p1::P1_07<Disconnected>,
+    pub p1_06: P1_06,
+    pub p1_07: P1_07,
     // pub p1_08: p1::P1_08<Disconnected>, // UART TX
-    pub p1_09: p1::P1_09<Disconnected>,
+    pub p1_09: P1_09,
 }
 
 /// Unused edge connector pins
@@ -338,22 +322,22 @@ pub struct Pins {
 pub struct Edge {
     /* edge connector */
     // pub e03: COL3,
-    pub e00: EDGE00<Disconnected>, // <- big pad 1
+    pub e00: EDGE00, // <- big pad 1
     // pub e04: COL1,
     // pub e05: BTN_A,
     // pub e06: COL4,
     // pub e07: COL2,
-    pub e01: EDGE01<Disconnected>, // <- big pad 2
-    pub e08: EDGE08<Disconnected>,
-    pub e09: EDGE09<Disconnected>,
+    pub e01: EDGE01, // <- big pad 2
+    pub e08: EDGE08,
+    pub e09: EDGE09,
     // pub e10: COL5,
     // pub e11: BTN_B,
-    pub e12: EDGE12<Disconnected>,
-    pub e02: EDGE02<Disconnected>, // <- big pad 3
+    pub e12: EDGE12,
+    pub e02: EDGE02, // <- big pad 3
     //pub e13<MODE>: SCK<MODE>,
     //pub e14<MODE>: MISO<MODE>,
     //pub e15<MODE>: MOSI<MODE>,
-    pub e16: EDGE16<Disconnected>,
+    pub e16: EDGE16,
     // +V
     // +V
     // +V
@@ -367,9 +351,9 @@ pub struct Edge {
 /// Buttons
 pub struct Buttons {
     /// Left hand button
-    pub button_a: BTN_A,
+    pub button_a: Input<'static>,
     /// Right hand button
-    pub button_b: BTN_B,
+    pub button_b: Input<'static>,
 }
 
 /// I2C internal bus pins
@@ -378,21 +362,13 @@ pub struct I2CInternalPins {
     sda: INT_SDA,
 }
 
-impl From<I2CInternalPins> for twim::Pins {
-    fn from(pins: I2CInternalPins) -> Self {
-        Self {
-            scl: pins.scl.degrade(),
-            sda: pins.sda.degrade(),
-        }
-    }
-}
-
-impl From<I2CInternalPins> for twis::Pins {
-    fn from(pins: I2CInternalPins) -> Self {
-        Self {
-            scl: pins.scl.degrade(),
-            sda: pins.sda.degrade(),
-        }
+impl I2CInternalPins {
+    /// Create a new uarte instance for the UART pins
+    pub fn create(self, p: TWISPI1, config: twim::Config) -> twim::Twim<'static, TWISPI1> {
+        bind_interrupts!(struct Irqs {
+            SPIM1_SPIS1_TWIM1_TWIS1_SPI1_TWI1 => twim::InterruptHandler<TWISPI1>;
+        });
+        twim::Twim::new(p, Irqs, self.scl, self.sda, config)
     }
 }
 
@@ -402,21 +378,13 @@ pub struct I2CExternalPins {
     sda: SDA,
 }
 
-impl From<I2CExternalPins> for twim::Pins {
-    fn from(pins: I2CExternalPins) -> Self {
-        Self {
-            scl: pins.scl.degrade(),
-            sda: pins.sda.degrade(),
-        }
-    }
-}
-
-impl From<I2CExternalPins> for twis::Pins {
-    fn from(pins: I2CExternalPins) -> Self {
-        Self {
-            scl: pins.scl.degrade(),
-            sda: pins.sda.degrade(),
-        }
+impl I2CExternalPins {
+    /// Create a new uarte instance for the UART pins
+    pub fn create(self, p: TWISPI0, config: twim::Config) -> twim::Twim<'static, TWISPI0> {
+        bind_interrupts!(struct Irqs {
+            SPIM0_SPIS0_TWIM0_TWIS0_SPI0_TWI0 => twim::InterruptHandler<TWISPI0>;
+        });
+        twim::Twim::new(p, Irqs, self.scl, self.sda, config)
     }
 }
 
@@ -426,13 +394,13 @@ pub struct UartPins {
     rx: UART_RX,
 }
 
-impl From<UartPins> for uarte::Pins {
-    fn from(pins: UartPins) -> Self {
-        Self {
-            txd: pins.tx.degrade(),
-            rxd: pins.rx.degrade(),
-            cts: None,
-            rts: None,
-        }
+impl UartPins {
+    /// Create a new uarte instance for the UART pins
+    pub fn create(self, p: UARTE0, config: uarte::Config) -> uarte::Uarte<'static, UARTE0> {
+        bind_interrupts!(struct Irqs {
+            UARTE0_UART0 => uarte::InterruptHandler<peripherals::UARTE0>;
+        });
+
+        return uarte::Uarte::new(p, Irqs, self.rx, self.tx, config);
     }
 }

--- a/microbit-common/src/v2/gpio.rs
+++ b/microbit-common/src/v2/gpio.rs
@@ -1,25 +1,30 @@
 #![allow(clippy::upper_case_acronyms, missing_docs)]
-use nrf52833_hal::gpio::{p0, p1, Floating, Input, OpenDrain, Output, Pin, PushPull};
+use embassy_nrf::gpio::{Level, Output, OutputDrive};
+use embassy_nrf::peripherals::{
+    P0_00, P0_01, P0_02, P0_03, P0_04, P0_05, P0_06, P0_08, P0_09, P0_10, P0_11, P0_12, P0_13,
+    P0_14, P0_15, P0_16, P0_17, P0_19, P0_20, P0_21, P0_22, P0_23, P0_24, P0_26, P0_28, P0_30,
+    P0_31, P1_00, P1_02, P1_05, P1_08,
+};
 
 /* GPIO pads */
-pub type PAD0<MODE> = p0::P0_02<MODE>;
-pub type PAD1<MODE> = p0::P0_03<MODE>;
-pub type PAD2<MODE> = p0::P0_04<MODE>;
+pub type PAD0 = P0_02;
+pub type PAD1 = P0_03;
+pub type PAD2 = P0_04;
 
 /* LED display */
 pub const NUM_COLS: usize = 5;
-pub type COL1 = p0::P0_28<Output<PushPull>>;
-pub type COL2 = p0::P0_11<Output<PushPull>>;
-pub type COL3 = p0::P0_31<Output<PushPull>>;
-pub type COL4 = p1::P1_05<Output<PushPull>>;
-pub type COL5 = p0::P0_30<Output<PushPull>>;
+pub type COL1 = P0_28;
+pub type COL2 = P0_11;
+pub type COL3 = P0_31;
+pub type COL4 = P1_05;
+pub type COL5 = P0_30;
 
 pub const NUM_ROWS: usize = 5;
-pub type ROW1 = p0::P0_21<Output<PushPull>>;
-pub type ROW2 = p0::P0_22<Output<PushPull>>;
-pub type ROW3 = p0::P0_15<Output<PushPull>>;
-pub type ROW4 = p0::P0_24<Output<PushPull>>;
-pub type ROW5 = p0::P0_19<Output<PushPull>>;
+pub type ROW1 = P0_21;
+pub type ROW2 = P0_22;
+pub type ROW3 = P0_15;
+pub type ROW4 = P0_24;
+pub type ROW5 = P0_19;
 
 /// GPIO pins connected to the LED matrix
 ///
@@ -39,28 +44,28 @@ pub struct DisplayPins {
 
 /// GPIO pins connected to the microphone
 pub struct MicrophonePins {
-    pub mic_in: p0::P0_05<Input<Floating>>,
-    pub mic_run: p0::P0_20<Output<OpenDrain>>,
+    pub mic_in: P0_05,
+    pub mic_run: P0_20,
 }
 
-type LED = Pin<Output<PushPull>>;
+type LED = Output<'static>;
 
 impl DisplayPins {
     pub fn degrade(self) -> ([LED; NUM_COLS], [LED; NUM_ROWS]) {
         (
             [
-                self.col1.degrade(),
-                self.col2.degrade(),
-                self.col3.degrade(),
-                self.col4.degrade(),
-                self.col5.degrade(),
+                Output::new(self.col1, Level::High, OutputDrive::Standard),
+                Output::new(self.col2, Level::High, OutputDrive::Standard),
+                Output::new(self.col3, Level::High, OutputDrive::Standard),
+                Output::new(self.col4, Level::High, OutputDrive::Standard),
+                Output::new(self.col5, Level::High, OutputDrive::Standard),
             ],
             [
-                self.row1.degrade(),
-                self.row2.degrade(),
-                self.row3.degrade(),
-                self.row4.degrade(),
-                self.row5.degrade(),
+                Output::new(self.row1, Level::Low, OutputDrive::Standard),
+                Output::new(self.row2, Level::Low, OutputDrive::Standard),
+                Output::new(self.row3, Level::Low, OutputDrive::Standard),
+                Output::new(self.row4, Level::Low, OutputDrive::Standard),
+                Output::new(self.row5, Level::Low, OutputDrive::Standard),
             ],
         )
     }
@@ -108,47 +113,47 @@ macro_rules! display_pins {
 }
 
 /* buttons */
-pub type BTN_A = p0::P0_14<Input<Floating>>;
-pub type BTN_B = p0::P0_23<Input<Floating>>;
+pub type BTN_A = P0_14;
+pub type BTN_B = P0_23;
 
 /* spi */
-pub type MOSI<MODE> = p0::P0_13<MODE>;
-pub type MISO<MODE> = p0::P0_01<MODE>;
-pub type SCK<MODE> = p0::P0_17<MODE>;
+pub type MOSI = P0_13;
+pub type MISO = P0_01;
+pub type SCK = P0_17;
 
 /* i2c - internal */
-pub type INT_SCL = p0::P0_08<Input<Floating>>;
-pub type INT_SDA = p0::P0_16<Input<Floating>>;
+pub type INT_SCL = P0_08;
+pub type INT_SDA = P0_16;
 
 /* i2c - external */
-pub type SCL = p0::P0_26<Input<Floating>>;
-pub type SDA = p1::P1_00<Input<Floating>>;
+pub type SCL = P0_26;
+pub type SDA = P1_00;
 
 /* uart */
-pub type UART_TX = p0::P0_06<Output<PushPull>>;
-pub type UART_RX = p1::P1_08<Input<Floating>>;
+pub type UART_TX = P0_06;
+pub type UART_RX = P1_08;
 
 /* speaker */
-pub type SPEAKER = p0::P0_00<Output<PushPull>>;
+pub type SPEAKER = P0_00;
 
 /* edge connector */
 pub type EDGE03 = COL3;
-pub type EDGE00<MODE> = PAD0<MODE>; // <- big pad 1
+pub type EDGE00 = PAD0; // <- big pad 1
 pub type EDGE04 = COL1;
 pub type EDGE05 = BTN_A;
 pub type EDGE06 = COL4;
 pub type EDGE07 = COL2;
-pub type EDGE01<MODE> = PAD1<MODE>; // <- big pad 2
-pub type EDGE08<MODE> = p0::P0_10<MODE>;
-pub type EDGE09<MODE> = p0::P0_09<MODE>;
+pub type EDGE01 = PAD1; // <- big pad 2
+pub type EDGE08 = P0_10;
+pub type EDGE09 = P0_09;
 pub type EDGE10 = COL5;
 pub type EDGE11 = BTN_B;
-pub type EDGE12<MODE> = p0::P0_12<MODE>;
-pub type EDGE02<MODE> = PAD2<MODE>; // <- big pad 3
-pub type EDGE13<MODE> = SCK<MODE>;
-pub type EDGE14<MODE> = MISO<MODE>;
-pub type EDGE15<MODE> = MOSI<MODE>;
-pub type EDGE16<MODE> = p1::P1_02<MODE>;
+pub type EDGE12 = P0_12;
+pub type EDGE02 = PAD2; // <- big pad 3
+pub type EDGE13 = SCK;
+pub type EDGE14 = MISO;
+pub type EDGE15 = MOSI;
+pub type EDGE16 = P1_02;
 // EDGE18 -> +V
 // EDGE19 -> +V
 // EDGE20 -> +V

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,8 @@
+[toolchain]
+channel = "1.76"
+components = [ "rust-src", "rustfmt", "llvm-tools" ]
+targets = [
+    "thumbv7em-none-eabi",
+    "thumbv6m-none-eabi",
+    "thumbv7em-none-eabihf",
+]


### PR DESCRIPTION
Here is an early show of what an (untested) port to Embassy would look like (Issue #125). I've only modified the existing display-blocking and display-nonblocking examples:

* [display-blocking](https://github.com/nrf-rs/microbit/blob/embassy-port/examples/display-blocking/src/main.rs)
* [display-nonblocking](https://github.com/nrf-rs/microbit/blob/embassy-port/examples/display-nonblocking/src/main.rs)

Arguably the display is the most HAL/PAC reliant part of this crate, things using RTC directly can use the 'system timer' instead, but having a custom timer for the display should work.

Most of the peripherals have just changed types.

Next I plan to modify the RTIC example, and also add an async variant of the display driver, reusing some ideas from microbit-bsp combined with the nonblocking driver that is there.
