### PR TITLE
export all peripherals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Add support for PPI
 - Servo example using TIMER, GPIOTE and PPI
 - (NFC) GitHub CI changes
+- Feature: Exposed all remaining peripherals for both boards.
 
 ## [0.13.0] - 2022-05-24
 

--- a/microbit-common/src/v1/board.rs
+++ b/microbit-common/src/v1/board.rs
@@ -106,6 +106,51 @@ pub struct Board {
 
     /// nrf51 peripheral: UART0
     pub UART0: pac::UART0,
+
+    /// nrf51 peripheral: POWER
+    pub POWER: pac::POWER,
+
+    /// nrf51 peripheral: SPI0
+    pub SPI0: pac::SPI0,
+
+    /// nrf51 peripheral: SPI1
+    pub SPI1: pac::SPI1,
+
+    /// nrf51 peripheral: TWI1
+    pub TWI1: pac::TWI1,
+
+    /// nrf51 peripheral: SPIS1
+    pub SPIS1: pac::SPIS1,
+
+    /// nrf51 peripheral: ECB
+    pub ECB: pac::ECB,
+
+    /// nrf51 peripheral: AAR
+    pub AAR: pac::AAR,
+
+    /// nrf51 peripheral: CCM
+    pub CCM: pac::CCM,
+
+    /// nrf51 peripheral: WDT
+    pub WDT: pac::WDT,
+
+    /// nrf51 peripheral: RTC1
+    pub RTC1: pac::RTC1,
+
+    /// nrf51 peripheral: QDEC
+    pub QDEC: pac::QDEC,
+
+    /// nrf51 peripheral: LPCOMP
+    pub LPCOMP: pac::LPCOMP,
+
+    /// nrf51 peripheral: SWI
+    pub SWI: pac::SWI,
+
+    /// nrf51 peripheral: NVMC
+    pub NVMC: pac::NVMC,
+
+    /// nrf51 peripheral: UICR
+    pub UICR: pac::UICR,
 }
 
 impl Board {
@@ -210,6 +255,21 @@ impl Board {
             TIMER2: p.TIMER2,
             TWI0: p.TWI0,
             UART0: p.UART0,
+            POWER: p.POWER,
+            SPI0: p.SPI0,
+            SPI1: p.SPI1,
+            TWI1: p.TWI1,
+            SPIS1: p.SPIS1,
+            ECB: p.ECB,
+            AAR: p.AAR,
+            CCM: p.CCM,
+            WDT: p.WDT,
+            RTC1: p.RTC1,
+            QDEC: p.QDEC,
+            LPCOMP: p.LPCOMP,
+            SWI: p.SWI,
+            NVMC: p.NVMC,
+            UICR: p.UICR,
         }
     }
 }

--- a/microbit-common/src/v2/board.rs
+++ b/microbit-common/src/v2/board.rs
@@ -148,6 +148,54 @@ pub struct Board {
 
     /// nRF52 peripheral: SAADC
     pub ADC: pac::SAADC,
+
+    /// nRF52 peripheral: POWER
+    pub POWER: pac::POWER,
+
+    /// nRF52 peripheral: SPI0
+    pub SPI0: pac::SPI0,
+
+    /// nRF52 peripheral: SPI1
+    pub SPI1: pac::SPI1,
+
+    /// nRF52 peripheral: SPI2
+    pub SPI2: pac::SPI2,
+
+    /// nRF52 peripheral: UART0
+    pub UART0: pac::UART0,
+
+    /// nRF52 peripheral: TWI0
+    pub TWI0: pac::TWI0,
+
+    /// nRF52 peripheral: TWI1
+    pub TWI1: pac::TWI1,
+
+    /// nRF52 peripheral: SPIS1
+    pub SPIS1: pac::SPIS1,
+
+    /// nRF52 peripheral: ECB
+    pub ECB: pac::ECB,
+
+    /// nRF52 peripheral: AAR
+    pub AAR: pac::AAR,
+
+    /// nRF52 peripheral: CCM
+    pub CCM: pac::CCM,
+
+    /// nRF52 peripheral: WDT
+    pub WDT: pac::WDT,
+
+    /// nRF52 peripheral: QDEC
+    pub QDEC: pac::QDEC,
+
+    /// nRF52 peripheral: LPCOMP
+    pub LPCOMP: pac::LPCOMP,
+
+    /// nRF52 peripheral: NVMC
+    pub NVMC: pac::NVMC,
+
+    /// nRF52 peripheral: UICR
+    pub UICR: pac::UICR,
 }
 
 impl Board {
@@ -282,6 +330,22 @@ impl Board {
             UARTE0: p.UARTE0,
             UARTE1: p.UARTE1,
             ADC: p.SAADC,
+            SPI0: p.SPI0,
+            SPI1: p.SPI1,
+            SPI2: p.SPI2,
+            POWER: p.POWER,
+            UART0: p.UART0,
+            TWI0: p.TWI0,
+            TWI1: p.TWI1,
+            SPIS1: p.SPIS1,
+            ECB: p.ECB,
+            AAR: p.AAR,
+            CCM: p.CCM,
+            WDT: p.WDT,
+            QDEC: p.QDEC,
+            LPCOMP: p.LPCOMP,
+            NVMC: p.NVMC,
+            UICR: p.UICR,
         }
     }
 }


### PR DESCRIPTION
My motivation for this was to use the SPI. I'm not sure if the idea was not to export all peripherals just to keep the API clean (or for some other reason), so fell free to close the PR if this doesn't fit the crate's goals.