### PR TITLE
Update HAL crates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Servo example using TIMER, GPIOTE and PPI
 - (NFC) GitHub CI changes
 - Feature: Exposed all remaining peripherals for both boards.
+- Updated HAL crates to latest versions.
 
 ## [0.13.0] - 2022-05-24
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,5 @@
 [workspace]
+resolver = "2"
 members = [
   "microbit-common",
   "microbit",

--- a/examples/analog-v1/Cargo.toml
+++ b/examples/analog-v1/Cargo.toml
@@ -11,6 +11,7 @@ cortex-m-rt = "0.7"
 panic-halt = "0.2.0"
 defmt-rtt = "0.3.2"
 defmt = "0.3.1"
+embedded-hal = "0.2.7"
 
 # NOTE: This currently only works with the microbit v1 due to naming issues!
 # ADC vs SAADC

--- a/examples/analog-v1/src/main.rs
+++ b/examples/analog-v1/src/main.rs
@@ -5,11 +5,11 @@ use defmt_rtt as _;
 use panic_halt as _;
 
 use cortex_m_rt::entry;
-
+use embedded_hal::adc::OneShot;
 use microbit::{
     board::Board,
     display::blocking::Display,
-    hal::{adc::AdcConfig, prelude::*, Adc, Timer},
+    hal::{adc::AdcConfig, Adc, Timer},
 };
 
 #[entry]

--- a/examples/analog-v2/Cargo.toml
+++ b/examples/analog-v2/Cargo.toml
@@ -11,6 +11,7 @@ cortex-m-rt = "0.7"
 panic-halt = "0.2.0"
 defmt-rtt = "0.3.2"
 defmt = "0.3.1"
+embedded-hal = "0.2.7"
 
 # NOTE: This currently only works with the microbit v2 due to naming issues!
 # ADC vs SAADC

--- a/examples/analog-v2/src/main.rs
+++ b/examples/analog-v2/src/main.rs
@@ -5,11 +5,11 @@ use defmt_rtt as _;
 use panic_halt as _;
 
 use cortex_m_rt::entry;
-
+use embedded_hal::adc::OneShot;
 use microbit::{
     board::Board,
     display::blocking::Display,
-    hal::{prelude::*, saadc::SaadcConfig, Saadc, Timer},
+    hal::{saadc::SaadcConfig, Saadc, Timer},
 };
 
 #[entry]

--- a/examples/analog/Cargo.toml
+++ b/examples/analog/Cargo.toml
@@ -11,6 +11,7 @@ cortex-m-rt = "0.7"
 panic-halt = "0.2.0"
 defmt-rtt = "0.3.2"
 defmt = "0.3.1"
+embedded-hal = "0.2.7"
 
 [dependencies.microbit]
 path = "../../microbit"

--- a/examples/analog/src/main.rs
+++ b/examples/analog/src/main.rs
@@ -5,12 +5,12 @@ use defmt_rtt as _;
 use panic_halt as _;
 
 use cortex_m_rt::entry;
-
+use embedded_hal::adc::OneShot;
 use microbit::{
     adc::{Adc, AdcConfig, Default},
     board::Board,
     display::blocking::Display,
-    hal::{prelude::*, Timer},
+    hal::Timer,
 };
 
 #[entry]

--- a/examples/display-blocking/Cargo.toml
+++ b/examples/display-blocking/Cargo.toml
@@ -9,6 +9,7 @@ cortex-m-rt = "0.7"
 panic-halt = "0.2.0"
 defmt-rtt = "0.4"
 defmt = "0.3.1"
+embedded-hal = "0.2.7"
 
 [dependencies.microbit]
 path = "../../microbit"

--- a/examples/display-blocking/src/main.rs
+++ b/examples/display-blocking/src/main.rs
@@ -5,12 +5,8 @@ use defmt_rtt as _;
 use panic_halt as _;
 
 use cortex_m_rt::entry;
-
-use microbit::{
-    board::Board,
-    display::blocking::Display,
-    hal::{prelude::*, Timer},
-};
+use embedded_hal::blocking::delay::DelayMs;
+use microbit::{board::Board, display::blocking::Display, hal::Timer};
 
 #[entry]
 fn main() -> ! {

--- a/examples/display-nonblocking/src/main.rs
+++ b/examples/display-nonblocking/src/main.rs
@@ -6,7 +6,6 @@ use panic_halt as _;
 
 use core::cell::RefCell;
 use cortex_m::interrupt::Mutex;
-use cortex_m::peripheral::Peripherals;
 use cortex_m_rt::entry;
 
 use microbit::{

--- a/examples/gpio-hal-ledbutton/Cargo.toml
+++ b/examples/gpio-hal-ledbutton/Cargo.toml
@@ -9,6 +9,7 @@ cortex-m-rt = "0.7"
 panic-halt = "0.2.0"
 defmt-rtt = "0.4"
 defmt = "0.3.1"
+embedded-hal = "0.2.7"
 
 [dependencies.microbit]
 path = "../../microbit"

--- a/examples/gpio-hal-ledbutton/src/main.rs
+++ b/examples/gpio-hal-ledbutton/src/main.rs
@@ -5,7 +5,8 @@ use defmt_rtt as _;
 use panic_halt as _;
 
 use cortex_m_rt::entry;
-use microbit::{board::Board, hal::prelude::*};
+use embedded_hal::digital::v2::{InputPin, OutputPin};
+use microbit::board::Board;
 
 #[entry]
 fn main() -> ! {

--- a/examples/magnetometer/Cargo.toml
+++ b/examples/magnetometer/Cargo.toml
@@ -10,6 +10,7 @@ panic-halt = "0.2.0"
 defmt-rtt = "0.4"
 defmt = "0.3"
 lsm303agr = "0.2.0"
+embedded-hal = "0.2.7"
 
 [dependencies.microbit]
 path = "../../microbit"

--- a/examples/magnetometer/src/main.rs
+++ b/examples/magnetometer/src/main.rs
@@ -5,8 +5,11 @@ use defmt_rtt as _;
 use panic_halt as _;
 
 use cortex_m_rt::entry;
-
-use microbit::hal::{prelude::*, Timer};
+use embedded_hal::blocking::delay::DelayMs;
+use lsm303agr::{
+    interface::I2cInterface, mode::MagOneShot, AccelMode, AccelOutputDataRate, Lsm303agr,
+};
+use microbit::hal::Timer;
 
 #[cfg(feature = "v1")]
 use microbit::{
@@ -17,10 +20,6 @@ use microbit::{
 use microbit::{
     hal::twim,
     pac::{twim0::frequency::FREQUENCY_A, TWIM0},
-};
-
-use lsm303agr::{
-    interface::I2cInterface, mode::MagOneShot, AccelMode, AccelOutputDataRate, Lsm303agr,
 };
 
 #[entry]

--- a/examples/serial-hal-blocking-echo/src/main.rs
+++ b/examples/serial-hal-blocking-echo/src/main.rs
@@ -4,17 +4,16 @@
 use panic_halt as _;
 
 use core::fmt::Write;
+use embedded_hal::serial::Read;
 
 #[cfg(feature = "v1")]
 use microbit::{
-    hal::prelude::*,
     hal::uart,
     hal::uart::{Baudrate, Parity},
 };
 
 #[cfg(feature = "v2")]
 use microbit::{
-    hal::prelude::*,
     hal::uarte,
     hal::uarte::{Baudrate, Parity},
 };

--- a/examples/v2-microphone/src/main.rs
+++ b/examples/v2-microphone/src/main.rs
@@ -5,13 +5,12 @@ use defmt_rtt as _;
 use panic_halt as _;
 
 use cortex_m_rt::entry;
-
+use embedded_hal::adc::OneShot;
 use microbit::{
     board::Board,
     display::blocking::Display,
     hal::{
         gpio::{Level, OpenDrainConfig},
-        prelude::*,
         saadc::SaadcConfig,
         Saadc, Timer,
     },

--- a/examples/v2-speaker/src/main.rs
+++ b/examples/v2-speaker/src/main.rs
@@ -6,14 +6,12 @@ use panic_halt as _;
 
 use core::cell::RefCell;
 use cortex_m::interrupt::Mutex;
-
 use cortex_m_rt::entry;
+use embedded_hal::digital::v2::OutputPin;
 use microbit::{
     hal::{
         clocks::Clocks,
-        gpio,
-        prelude::OutputPin,
-        pwm,
+        gpio, pwm,
         rtc::{Rtc, RtcInterrupt},
         time::Hertz,
     },

--- a/microbit-common/Cargo.toml
+++ b/microbit-common/Cargo.toml
@@ -30,11 +30,11 @@ embedded-hal = "0.2.4"
 
 [dependencies.nrf51-hal]
 optional = true
-version = "0.14.0"
+version = "0.17.0"
 
 [dependencies.nrf52833-hal]
 optional = true
-version = "0.14.0"
+version = "0.17.0"
 
 [features]
 doc = []

--- a/microbit-common/src/display/blocking.rs
+++ b/microbit-common/src/display/blocking.rs
@@ -63,14 +63,9 @@
 //! Will display an arrow pointing towards the boards usb port.
 //!
 //! For a working example [`examples/display-blocking`](https://github.com/nrf-rs/microbit/tree/main/examples/display-blocking)
-use crate::hal::{
-    gpio::{Output, Pin, PushPull},
-    prelude::*,
-};
-
 use crate::gpio::{DisplayPins, NUM_COLS, NUM_ROWS};
-
-use embedded_hal::blocking::delay::DelayUs;
+use crate::hal::gpio::{Output, Pin, PushPull};
+use embedded_hal::{blocking::delay::DelayUs, digital::v2::OutputPin};
 
 #[allow(clippy::upper_case_acronyms)]
 pub(crate) type LED = Pin<Output<PushPull>>;


### PR DESCRIPTION
For now this still uses `embedded-hal` 0.2, the update to using 1.0 traits will be a separate PR.