### PR TITLE
Update installation instruction for `probe-rs`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 
 - Update HAL crates to 0.18.0.
+* Update installation instructions for `probe-rs`
 
 ## [0.14.0] - 2024-04-18
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ In order to run the examples you need to install [`probe-rs`](https://probe.rs/d
 and [`flip-link`](https://github.com/knurling-rs/flip-link#installation).
 
 ```bash
-> cargo install probe-rs flip-link
+> cargo install probe-rs-tools flip-link
 ```
 
 ### Run an example


### PR DESCRIPTION
The binary `probe-rs` tools has been moved to it's own crate: `probe-rs-tools`. Therefore, the current instructions are outdated and fail:

```bash
$ cargo install probe-rs
    Updating crates.io index
  Downloaded probe-rs v0.24.0
  Downloaded 1 crate (1.7 MB) in 0.35s
error: there is nothing to install in `probe-rs v0.24.0`, because it has no binaries
`cargo install` is only for installing programs, and can't be used with libraries.
To use a library crate, add it as a dependency to a Cargo project with `cargo add`.
```

This commit updates the installation instruction.
For more information, see the [probe-rs' changelog][^1].

[^1]: https://github.com/probe-rs/probe-rs/blob/master/CHANGELOG.md#0240