### PR TITLE
made sda and scl public for i2c interfaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-## [Unreleased]
+## [0.15.1] - 2024-07-30
 
 - Set MSRV for `microbit` and `microbit-v2` crates.
 - Bumped MSRV to 1.79.0.
+- Make various `I2C` `Pin` fields `pub`
 
 ## [0.15.0] - 2024-06-19
 

--- a/microbit-common/src/v1/board.rs
+++ b/microbit-common/src/v1/board.rs
@@ -350,8 +350,10 @@ pub struct Buttons {
 
 /// I2C shared internal and external bus pins
 pub struct I2CPins {
-    scl: SCL,
-    sda: SDA,
+    /// I2C control pin
+    pub scl: SCL,
+    /// I2C data pin
+    pub sda: SDA,
 }
 
 impl From<I2CPins> for twi::Pins {

--- a/microbit-common/src/v2/board.rs
+++ b/microbit-common/src/v2/board.rs
@@ -438,8 +438,10 @@ pub struct Buttons {
 
 /// I2C internal bus pins
 pub struct I2CInternalPins {
-    scl: INT_SCL,
-    sda: INT_SDA,
+    /// Internal I2C clock pin
+    pub scl: INT_SCL,
+    /// Internal I2C data pin
+    pub sda: INT_SDA,
 }
 
 impl From<I2CInternalPins> for twim::Pins {
@@ -462,8 +464,10 @@ impl From<I2CInternalPins> for twis::Pins {
 
 /// I2C external bus pins
 pub struct I2CExternalPins {
-    scl: SCL,
-    sda: SDA,
+    /// External I2C clock pin
+    pub scl: SCL,
+    /// External I2C data pin
+    pub sda: SDA,
 }
 
 impl From<I2CExternalPins> for twim::Pins {

--- a/microbit-v2/Cargo.toml
+++ b/microbit-v2/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "microbit-v2"
-version = "0.15.0"
+version = "0.15.1"
 description = "Board support crate for the BBC Micro:bit V2"
 edition = "2018"
 readme = "../README.md"

--- a/microbit/Cargo.toml
+++ b/microbit/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "microbit"
-version = "0.15.0"
+version = "0.15.1"
 description = "Board support crate for the BBC Micro:bit V1"
 edition = "2018"
 readme = "../README.md"


### PR DESCRIPTION
Made the `sda` and `scl` pins in the various `I2c` `Pins` struct public.

Closes #150