### PR TITLE
removed broken link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
-(no changes)
+- Remove dead link to microbit Rust on Windows blog post in README.
 
 ## [0.15.1] - 2024-08-05
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ even a capable debugging interface.
 All you need to start programming this device is:
 
 * A BBC micro:bit board
-* A computer (macOS and Linux work perfectly, [Windows tested as well](http://flames-of-code.netlify.com/blog/rust-microbit-windows/))
+* A computer (known to work with macOS, Linux and Windows)
 * A bit of open source software
 
 ### Know your version


### PR DESCRIPTION
Don't have a current link for the microbit-Rust-on-Windows blog entry in the README, so just deleted it for now.

closes #157. closes #162