### PR TITLE
Bump MSRV to 1.81.0.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -28,7 +28,7 @@ jobs:
           # Note this needs to be new enough to build the examples as well as
           # the library itself.
           - name: MSRV
-            rust: 1.79.0
+            rust: 1.81.0
 
     name: "build (${{ matrix.name || matrix.rust }})"
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 
 - Remove dead link to microbit Rust on Windows blog post in README.
+- Bumped MSRV to 1.81.0.
 
 ## [0.15.1] - 2024-08-05
 


### PR DESCRIPTION
This is required to build the latest version of flip-link, which is used in our CI.